### PR TITLE
[Catalog] Register TR-LALM on v4.32.2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,10 +13,12 @@ matches the Lean/mathlib version of your book project:
 v4.26.0
 v4.30.0
 v4.32.0
+v4.32.2
 ```
 
-ReasBook only accepts stable `vX.Y.0` versions, i.e. the patch version must be `0`.
-Other patch versions (`vX.Y.1`), release candidates, and nightlies are **not** accepted.
+ReasBook only accepts stable `vX.Y.Z` versions that are registered in the main
+README and `config/toolchains.yml`. Patch releases are allowed when explicitly
+registered; release candidates and nightlies are **not** accepted.
 The PR target version must match `ReasBook/lean-toolchain`. Do **not** target `main` with book code.
 
 If the version you need is not listed, contact a maintainer. Do not switch to a nearby version
@@ -29,7 +31,7 @@ latest state of the target version branch:
 
 ```bash
 git fetch upstream
-git switch -c book/<book-slug> upstream/vX.Y.0
+git switch -c book/<book-slug> upstream/vX.Y.Z
 ```
 
 Use lowercase letters, digits, and hyphens for the branch name, for example:
@@ -95,7 +97,7 @@ runner; for local verification, `lake build` passing is usually sufficient.
 Before committing, check that you did not accidentally delete files from the target branch:
 
 ```bash
-git diff --diff-filter=D --name-status upstream/vX.Y.0...HEAD
+git diff --diff-filter=D --name-status upstream/vX.Y.Z...HEAD
 ```
 
 Apart from intentional replacements inside your own book, there should be no deletions of other
@@ -106,19 +108,19 @@ books or papers.
 Set the PR base to the matching version branch:
 
 ```text
-vX.Y.0
+vX.Y.Z
 ```
 
 New book PR title:
 
 ```text
-[Book][vX.Y.0] Add <BookId>
+[Book][vX.Y.Z] Add <BookId>
 ```
 
 Update PR title:
 
 ```text
-[Book][vX.Y.0] Update <BookId>: <short-scope>
+[Book][vX.Y.Z] Update <BookId>: <short-scope>
 ```
 
 For example:
@@ -135,7 +137,7 @@ For example:
 - **Book:** <Title> — <Author full name> (<Edition, Year>)
 - **Book ID:** `<BookId>`
 - **Contributor:** <Name> (@<GitHub-ID>)
-- **Target branch:** `vX.Y.0`
+- **Target branch:** `vX.Y.Z`
 - **Lean toolchain:** `<full content of ReasBook/lean-toolchain>`
 - **Declarations:** <total> (theorem/lemma/example: <count>; other: <count>)
 - **Lean code:** <file-count> `.lean` files, <line-count> lines
@@ -150,7 +152,7 @@ For example:
 
 ## Pre-submission checklist
 
-- Personal branch created from the correct `upstream/vX.Y.0`.
+- Personal branch created from the correct `upstream/vX.Y.Z`.
 - PR base, PR title, and `lean-toolchain` version are consistent.
 - Branch name, book directory name, and PR title follow the conventions.
 - Book `README.md` and contributor info are complete.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ ReasBook is generated using the tool: [M2F](https://github.com/optsuite/M2F.git)
 | Branch | Lean/mathlib | Status | Books/Papers | Last build |
 | --- | --- | --- | ---: | --- |
 | `v4.32.0` | `v4.32.0` | Empty | 0 / 0 | Passed |
+| `v4.32.2` | `v4.32.2` | Active | 0 / 1 | Passed |
 | `v4.30.0` | `v4.30.0` | Active | 8 / 2 | Passed |
 | `v4.26.0` | `v4.26.0` | Active | 4 / 2 | Passed |
 
@@ -35,14 +36,22 @@ Status: `Empty` (initialized, no books yet) · `Active` (accepting PRs) · `Froz
 
 | Paper | Branch | Contributors | Documentation | Source | Verso |
 | --- | --- | --- | --- | --- | --- |
+| A Fixed-Penalty Linearized Augmented Lagrangian Method with Classical Multiplier Updates — Benqi Liu, Kangkang Deng, Zichen Wang, Zaiwen Wen | `v4.32.2` | Zichen Wang | [doc](https://optpku.github.io/ReasBook/docs/TR_LALM_theory/Paper.html) | [v4.32.2](https://github.com/optpku/ReasBook/tree/v4.32.2/ReasBook/Papers/TR_LALM_theory/) | [verso](https://optpku.github.io/ReasBook/papers/tr_lalm_theory/) |
 | Smooth Minimization of Non-Smooth Functions — Yurii Nesterov (2004) | `v4.26.0` / `v4.30.0` | Wanli Ma, Zichen Wang | [doc v4.26.0](https://optpku.github.io/ReasBook/docs/Papers/SmoothMinimization_Nesterov_2004/Paper.html) / [doc v4.30.0](https://optpku.github.io/ReasBook/docs/SmoothMinimization_Nesterov_2004/Paper.html) | [v4.26.0](https://github.com/optpku/ReasBook/tree/v4.26.0/ReasBook/Papers/SmoothMinimization_Nesterov_2004/) / [v4.30.0](https://github.com/optpku/ReasBook/tree/v4.30.0/ReasBook/Papers/SmoothMinimization_Nesterov_2004/) | [verso](https://optpku.github.io/ReasBook/papers/smoothminimization_nesterov_2004/) |
 | On Some Local Rings — Mohamad Maassarani (2025) | `v4.26.0` / `v4.30.0` | Liang Xiao, Haochen Ju, Zichen Wang | [doc v4.26.0](https://optpku.github.io/ReasBook/docs/Papers/OnSomeLocalRings_Maassaran_2025/Paper.html) / [doc v4.30.0](https://optpku.github.io/ReasBook/docs/OnSomeLocalRings_Maassaran_2025/Paper.html) | [v4.26.0](https://github.com/optpku/ReasBook/tree/v4.26.0/ReasBook/Papers/OnSomeLocalRings_Maassaran_2025/) / [v4.30.0](https://github.com/optpku/ReasBook/tree/v4.30.0/ReasBook/Papers/OnSomeLocalRings_Maassaran_2025/) | [verso](https://optpku.github.io/ReasBook/papers/onsomelocalrings_maassaran_2025/) |
+
+The TR-LALM entry formalizes the fixed-penalty linearized augmented
+Lagrangian analysis for nonlinear equality-constrained nonconvex optimization,
+including deterministic and stochastic complexity, stopping/restart semantics,
+finite-length KL convergence, and the optional minimum-norm correction. Its Lean
+source has 2,853 declarations across 141 implementation files, with no `sorry`
+or `admit` placeholders.
 
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).
 
-- Book code lives on the version branch matching its Lean/mathlib toolchain; only `vX.Y.0` versions are accepted.
+- Book and paper code lives on the registered version branch matching its Lean/mathlib toolchain; only registered stable `vX.Y.Z` versions are accepted.
 - **Book code is not merged to `main`.** `main` is the cross-version catalog only.
 - PR base, PR title version, `ReasBook/lean-toolchain`, and `book.yml` must all match.
 

--- a/config/book.yml.example
+++ b/config/book.yml.example
@@ -14,9 +14,9 @@ publisher: "<Publisher, City or null>"
 year: <YYYY>
 isbn: "<ISBN or null>"
 
-toolchain: "leanprover/lean4:vX.Y.0"
-mathlib: "vX.Y.0"
-branch: "vX.Y.0"
+toolchain: "leanprover/lean4:vX.Y.Z"
+mathlib: "vX.Y.Z"
+branch: "vX.Y.Z"
 
 contributors:
   - name: "<Name>"

--- a/config/toolchains.yml
+++ b/config/toolchains.yml
@@ -18,3 +18,8 @@ branches:
     branch: v4.32.0
     status: empty
     initialization: automatic
+
+  - version: v4.32.2
+    branch: v4.32.2
+    status: active
+    initialization: direct


### PR DESCRIPTION
## Catalog update

- Registers the `v4.32.2` Lean/mathlib toolchain in `config/toolchains.yml`.
- Adds the TR-LALM paper to the main README's paper catalog and gives a short overview of its formalized results.
- Records the paper source, documentation, and Verso links using the official `optpku/ReasBook` repository and versioned branch.
- Updates contribution templates and policy to allow explicitly registered stable patch versions such as `v4.32.2`.

This PR targets `main` and contains catalog/metadata changes only; the formalization itself is proposed separately against `v4.32.2`.