### PR TITLE
[Web] Generate cross-version theorem dependency maps

### DIFF
--- a/.github/workflows/deploy_pages.yml
+++ b/.github/workflows/deploy_pages.yml
@@ -142,6 +142,14 @@ jobs:
           ref: ${{ matrix.branch }}
           fetch-depth: 0
 
+      - name: Checkout theorem-map generator from main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          path: .reasbook-main
+          sparse-checkout: |
+            tools/theorem_map
+
       - name: Prepare persistent build directories
         run: |
           set -euo pipefail
@@ -288,6 +296,18 @@ jobs:
           set -euo pipefail
           ./scripts/ci_heartbeat.sh "assemble_site_docs.sh (${BRANCH})" ./scripts/assemble_site_docs.sh
 
+      - name: Generate theorem dependency maps (${BRANCH})
+        timeout-minutes: 30
+        run: |
+          set -euo pipefail
+          python3 .reasbook-main/tools/theorem_map/generate_all.py \
+            --repo-root . \
+            --site-root ReasBookWeb/_site \
+            --branch "$BRANCH" \
+            --repository "https://github.com/${GITHUB_REPOSITORY}" \
+            --extractor .reasbook-main/tools/theorem_map/Extract.lean \
+            --assets .reasbook-main/tools/theorem_map/assets
+
       - name: Upload branch site artifact
         uses: actions/upload-artifact@v4
         with:
@@ -429,6 +449,7 @@ jobs:
 
               pages_src = dst_root / kind / slug
               docs_src = dst_root / "docs" / kind_title / name
+              map_src = dst_root / "theorem-maps" / kind / slug
               site_dir = sites_root / slug
 
               if site_dir.exists():
@@ -439,6 +460,16 @@ jobs:
                   shutil.copytree(pages_src, site_dir / "pages")
               if docs_src.is_dir():
                   shutil.copytree(docs_src, site_dir / "docs")
+
+              navigation = []
+              if pages_src.is_dir():
+                  navigation.append('    <li><a href="./pages/">Pages</a></li>')
+              if docs_src.is_dir():
+                  navigation.append('    <li><a href="./docs/">Documentation</a></li>')
+              if map_src.is_dir():
+                  navigation.append(
+                      f'    <li><a href="../../theorem-maps/{kind}/{slug}/">Theorem map</a></li>'
+                  )
 
               index = site_dir / "index.html"
               index.write_text(
@@ -454,8 +485,7 @@ jobs:
                           "<body>",
                           f"  <h1>{name}</h1>",
                           "  <ul>",
-                          '    <li><a href="./pages/">Pages</a></li>',
-                          '    <li><a href="./docs/">Documentation</a></li>',
+                          *navigation,
                           "  </ul>",
                           '  <p><a href="../../">Back to root</a></p>',
                           "</body>",
@@ -496,11 +526,17 @@ jobs:
               )
           PY
 
+      - name: Rebuild cross-version theorem-map catalog
+        run: |
+          set -euo pipefail
+          python3 tools/theorem_map/catalog.py --site-root .site
+
       - name: Verify generated site tree
         run: |
           set -euo pipefail
           ls -la .site
           test -d .site/docs
+          test -f .site/theorem-maps/index.html
 
       - name: Compute Pages artifact name
         id: pages_artifact_name

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Each directory in these indexes is a landing page for one book or paper. Open a 
 
 - [Books](https://github.com/optpku/ReasBook/tree/main/ReasBook/Books/)
 - [Papers](https://github.com/optpku/ReasBook/tree/main/ReasBook/Papers/)
+- [Theorem dependency maps](https://optpku.github.io/ReasBook/theorem-maps/)
 
 ## Books
 

--- a/ReasBook/Books/AlgebraicTopology_May_1999/README.md
+++ b/ReasBook/Books/AlgebraicTopology_May_1999/README.md
@@ -2,4 +2,6 @@
 
 This is a catalog link folder on `main`; the Lean source is kept on the version branch.
 
+**[Open the theorem dependency map](https://optpku.github.io/ReasBook/theorem-maps/books/algebraictopology_may_1999/)**
+
 **[Open the source on `v4.30.0`](https://github.com/optpku/ReasBook/tree/v4.30.0/ReasBook/Books/AlgebraicTopology_May_1999/)**

--- a/ReasBook/Books/Analysis2_Tao_2022/README.md
+++ b/ReasBook/Books/Analysis2_Tao_2022/README.md
@@ -2,6 +2,8 @@
 
 This is a catalog link folder on `main`; the Lean source is available on both registered branches.
 
+**[Open the theorem dependency map](https://optpku.github.io/ReasBook/theorem-maps/books/analysis2_tao_2022/)**
+
 **[Open the source on `v4.26.0`](https://github.com/optpku/ReasBook/tree/v4.26.0/ReasBook/Books/Analysis2_Tao_2022/)**
 
 **[Open the source on `v4.30.0`](https://github.com/optpku/ReasBook/tree/v4.30.0/ReasBook/Books/Analysis2_Tao_2022/)**

--- a/ReasBook/Books/CombinatorialGroupTheory_Magnus_2004/README.md
+++ b/ReasBook/Books/CombinatorialGroupTheory_Magnus_2004/README.md
@@ -2,4 +2,6 @@
 
 This is a catalog link folder on `main`; the Lean source is kept on the version branch.
 
+**[Open the theorem dependency map](https://optpku.github.io/ReasBook/theorem-maps/books/combinatorialgrouptheory_magnus_2004/)**
+
 **[Open the source on `v4.30.0`](https://github.com/optpku/ReasBook/tree/v4.30.0/ReasBook/Books/CombinatorialGroupTheory_Magnus_2004/)**

--- a/ReasBook/Books/ConvexAnalysisMonotoneOperators_BauschkeCombettes_2017/README.md
+++ b/ReasBook/Books/ConvexAnalysisMonotoneOperators_BauschkeCombettes_2017/README.md
@@ -2,4 +2,6 @@
 
 This is a catalog link folder on `main`; the Lean source is kept on the version branch.
 
+**[Open the theorem dependency map](https://optpku.github.io/ReasBook/theorem-maps/books/convexanalysismonotoneoperators_bauschkecombettes_2017/)**
+
 **[Open the source on `v4.30.0`](https://github.com/optpku/ReasBook/tree/v4.30.0/ReasBook/Books/ConvexAnalysisMonotoneOperators_BauschkeCombettes_2017/)**

--- a/ReasBook/Books/ConvexAnalysis_Rockafellar_1970/README.md
+++ b/ReasBook/Books/ConvexAnalysis_Rockafellar_1970/README.md
@@ -2,4 +2,6 @@
 
 This is a catalog link folder on `main`; the Lean source is kept on the version branch.
 
+**[Open the theorem dependency map](https://optpku.github.io/ReasBook/theorem-maps/books/convexanalysis_rockafellar_1970/)**
+
 **[Open the source on `v4.26.0`](https://github.com/optpku/ReasBook/tree/v4.26.0/ReasBook/Books/ConvexAnalysis_Rockafellar_1970/)**

--- a/ReasBook/Books/FirstOrderMethodsOptimization_Beck_2017/README.md
+++ b/ReasBook/Books/FirstOrderMethodsOptimization_Beck_2017/README.md
@@ -2,4 +2,6 @@
 
 This is a catalog link folder on `main`; the Lean source is kept on the version branch.
 
+**[Open the theorem dependency map](https://optpku.github.io/ReasBook/theorem-maps/books/firstordermethodsoptimization_beck_2017/)**
+
 **[Open the source on `v4.30.0`](https://github.com/optpku/ReasBook/tree/v4.30.0/ReasBook/Books/FirstOrderMethodsOptimization_Beck_2017/)**

--- a/ReasBook/Books/IntegerProgramming_Conforti_2014/README.md
+++ b/ReasBook/Books/IntegerProgramming_Conforti_2014/README.md
@@ -2,4 +2,6 @@
 
 This is a catalog link folder on `main`; the Lean source is kept on the version branch.
 
+**[Open the theorem dependency map](https://optpku.github.io/ReasBook/theorem-maps/books/integerprogramming_conforti_2014/)**
+
 **[Open the source on `v4.26.0`](https://github.com/optpku/ReasBook/tree/v4.26.0/ReasBook/Books/IntegerProgramming_Conforti_2014/)**

--- a/ReasBook/Books/IntroductiontoRealAnalysisVolumeI_JiriLebl_2025/README.md
+++ b/ReasBook/Books/IntroductiontoRealAnalysisVolumeI_JiriLebl_2025/README.md
@@ -2,6 +2,8 @@
 
 This is a catalog link folder on `main`; the Lean source is available on both registered branches.
 
+**[Open the theorem dependency map](https://optpku.github.io/ReasBook/theorem-maps/books/introductiontorealanalysisvolumei_jirilebl_2025/)**
+
 **[Open the source on `v4.26.0`](https://github.com/optpku/ReasBook/tree/v4.26.0/ReasBook/Books/IntroductiontoRealAnalysisVolumeI_JiriLebl_2025/)**
 
 **[Open the source on `v4.30.0`](https://github.com/optpku/ReasBook/tree/v4.30.0/ReasBook/Books/IntroductiontoRealAnalysisVolumeI_JiriLebl_2025/)**

--- a/ReasBook/Books/ProbabilityTheory_Klenke_2020/README.md
+++ b/ReasBook/Books/ProbabilityTheory_Klenke_2020/README.md
@@ -2,4 +2,6 @@
 
 This is a catalog link folder on `main`; the Lean source is kept on the version branch.
 
+**[Open the theorem dependency map](https://optpku.github.io/ReasBook/theorem-maps/books/probabilitytheory_klenke_2020/)**
+
 **[Open the source on `v4.30.0`](https://github.com/optpku/ReasBook/tree/v4.30.0/ReasBook/Books/ProbabilityTheory_Klenke_2020/)**

--- a/ReasBook/Books/README.md
+++ b/ReasBook/Books/README.md
@@ -3,15 +3,15 @@
 The `main` branch contains catalog link folders, not duplicate Lean sources.
 Open a title below and use its source link to jump to the matching version branch.
 
-| Book | Link folder |
-| --- | --- |
-| [A Concise Course in Algebraic Topology - J. Peter May (1999)](./AlgebraicTopology_May_1999/) | `v4.30.0` |
-| [Analysis II - Terence Tao (4th ed., 2022)](./Analysis2_Tao_2022/) | `v4.26.0`, `v4.30.0` |
-| [Combinatorial Group Theory - Magnus, Karrass, Solitar (2004)](./CombinatorialGroupTheory_Magnus_2004/) | `v4.30.0` |
-| [Convex Analysis - R. Tyrrell Rockafellar (1970)](./ConvexAnalysis_Rockafellar_1970/) | `v4.26.0` |
-| [Convex Analysis and Monotone Operator Theory - Bauschke, Combettes (2017)](./ConvexAnalysisMonotoneOperators_BauschkeCombettes_2017/) | `v4.30.0` |
-| [First-Order Methods in Optimization - Amir Beck (2017)](./FirstOrderMethodsOptimization_Beck_2017/) | `v4.30.0` |
-| [Integer Programming - Conforti, Cornuejols, Zambelli (2014)](./IntegerProgramming_Conforti_2014/) | `v4.26.0` |
-| [Introduction to Real Analysis, Volume I - Jiri Lebl (2025)](./IntroductiontoRealAnalysisVolumeI_JiriLebl_2025/) | `v4.26.0`, `v4.30.0` |
-| [Probability Theory - Achim Klenke (2020)](./ProbabilityTheory_Klenke_2020/) | `v4.30.0` |
-| [Lectures on Riemann Surfaces - Otto Forster (1981)](./RiemannSurfaces_Forster_1981/) | `v4.30.0` |
+| Book | Branch | Theorem map |
+| --- | --- | --- |
+| [A Concise Course in Algebraic Topology - J. Peter May (1999)](./AlgebraicTopology_May_1999/) | `v4.30.0` | [map](https://optpku.github.io/ReasBook/theorem-maps/books/algebraictopology_may_1999/) |
+| [Analysis II - Terence Tao (4th ed., 2022)](./Analysis2_Tao_2022/) | `v4.26.0`, `v4.30.0` | [map](https://optpku.github.io/ReasBook/theorem-maps/books/analysis2_tao_2022/) |
+| [Combinatorial Group Theory - Magnus, Karrass, Solitar (2004)](./CombinatorialGroupTheory_Magnus_2004/) | `v4.30.0` | [map](https://optpku.github.io/ReasBook/theorem-maps/books/combinatorialgrouptheory_magnus_2004/) |
+| [Convex Analysis - R. Tyrrell Rockafellar (1970)](./ConvexAnalysis_Rockafellar_1970/) | `v4.26.0` | [map](https://optpku.github.io/ReasBook/theorem-maps/books/convexanalysis_rockafellar_1970/) |
+| [Convex Analysis and Monotone Operator Theory - Bauschke, Combettes (2017)](./ConvexAnalysisMonotoneOperators_BauschkeCombettes_2017/) | `v4.30.0` | [map](https://optpku.github.io/ReasBook/theorem-maps/books/convexanalysismonotoneoperators_bauschkecombettes_2017/) |
+| [First-Order Methods in Optimization - Amir Beck (2017)](./FirstOrderMethodsOptimization_Beck_2017/) | `v4.30.0` | [map](https://optpku.github.io/ReasBook/theorem-maps/books/firstordermethodsoptimization_beck_2017/) |
+| [Integer Programming - Conforti, Cornuejols, Zambelli (2014)](./IntegerProgramming_Conforti_2014/) | `v4.26.0` | [map](https://optpku.github.io/ReasBook/theorem-maps/books/integerprogramming_conforti_2014/) |
+| [Introduction to Real Analysis, Volume I - Jiri Lebl (2025)](./IntroductiontoRealAnalysisVolumeI_JiriLebl_2025/) | `v4.26.0`, `v4.30.0` | [map](https://optpku.github.io/ReasBook/theorem-maps/books/introductiontorealanalysisvolumei_jirilebl_2025/) |
+| [Probability Theory - Achim Klenke (2020)](./ProbabilityTheory_Klenke_2020/) | `v4.30.0` | [map](https://optpku.github.io/ReasBook/theorem-maps/books/probabilitytheory_klenke_2020/) |
+| [Lectures on Riemann Surfaces - Otto Forster (1981)](./RiemannSurfaces_Forster_1981/) | `v4.30.0` | [map](https://optpku.github.io/ReasBook/theorem-maps/books/riemannsurfaces_forster_1981/) |

--- a/ReasBook/Books/RiemannSurfaces_Forster_1981/README.md
+++ b/ReasBook/Books/RiemannSurfaces_Forster_1981/README.md
@@ -2,4 +2,6 @@
 
 This is a catalog link folder on `main`; the Lean source is kept on the version branch.
 
+**[Open the theorem dependency map](https://optpku.github.io/ReasBook/theorem-maps/books/riemannsurfaces_forster_1981/)**
+
 **[Open the source on `v4.30.0`](https://github.com/optpku/ReasBook/tree/v4.30.0/ReasBook/Books/RiemannSurfaces_Forster_1981/)**

--- a/ReasBook/Papers/OnSomeLocalRings_Maassaran_2025/README.md
+++ b/ReasBook/Papers/OnSomeLocalRings_Maassaran_2025/README.md
@@ -2,6 +2,8 @@
 
 This is a catalog link folder on `main`; the Lean source is available on both registered branches.
 
+**[Open the theorem dependency map](https://optpku.github.io/ReasBook/theorem-maps/papers/onsomelocalrings_maassaran_2025/)**
+
 **[Open the source on `v4.26.0`](https://github.com/optpku/ReasBook/tree/v4.26.0/ReasBook/Papers/OnSomeLocalRings_Maassaran_2025/)**
 
 **[Open the source on `v4.30.0`](https://github.com/optpku/ReasBook/tree/v4.30.0/ReasBook/Papers/OnSomeLocalRings_Maassaran_2025/)**

--- a/ReasBook/Papers/README.md
+++ b/ReasBook/Papers/README.md
@@ -3,8 +3,8 @@
 The `main` branch contains catalog link folders, not duplicate Lean sources.
 Open a paper below and use its source link to jump to the matching version branch.
 
-| Paper | Link folder |
-| --- | --- |
-| [A Fixed-Penalty Linearized Augmented Lagrangian Method with Classical Multiplier Updates](./TR_LALM_theory/) | `v4.32.2` |
-| [Smooth Minimization of Non-Smooth Functions - Yurii Nesterov (2004)](./SmoothMinimization_Nesterov_2004/) | `v4.26.0`, `v4.30.0` |
-| [On Some Local Rings - Mohamad Maassarani (2025)](./OnSomeLocalRings_Maassaran_2025/) | `v4.26.0`, `v4.30.0` |
+| Paper | Branch | Theorem map |
+| --- | --- | --- |
+| [A Fixed-Penalty Linearized Augmented Lagrangian Method with Classical Multiplier Updates](./TR_LALM_theory/) | `v4.32.2` | [map](https://optpku.github.io/ReasBook/theorem-maps/papers/tr_lalm_theory/) |
+| [Smooth Minimization of Non-Smooth Functions - Yurii Nesterov (2004)](./SmoothMinimization_Nesterov_2004/) | `v4.26.0`, `v4.30.0` | [map](https://optpku.github.io/ReasBook/theorem-maps/papers/smoothminimization_nesterov_2004/) |
+| [On Some Local Rings - Mohamad Maassarani (2025)](./OnSomeLocalRings_Maassaran_2025/) | `v4.26.0`, `v4.30.0` | [map](https://optpku.github.io/ReasBook/theorem-maps/papers/onsomelocalrings_maassaran_2025/) |

--- a/ReasBook/Papers/SmoothMinimization_Nesterov_2004/README.md
+++ b/ReasBook/Papers/SmoothMinimization_Nesterov_2004/README.md
@@ -2,6 +2,8 @@
 
 This is a catalog link folder on `main`; the Lean source is available on both registered branches.
 
+**[Open the theorem dependency map](https://optpku.github.io/ReasBook/theorem-maps/papers/smoothminimization_nesterov_2004/)**
+
 **[Open the source on `v4.26.0`](https://github.com/optpku/ReasBook/tree/v4.26.0/ReasBook/Papers/SmoothMinimization_Nesterov_2004/)**
 
 **[Open the source on `v4.30.0`](https://github.com/optpku/ReasBook/tree/v4.30.0/ReasBook/Papers/SmoothMinimization_Nesterov_2004/)**

--- a/ReasBook/Papers/TR_LALM_theory/README.md
+++ b/ReasBook/Papers/TR_LALM_theory/README.md
@@ -2,7 +2,8 @@
 
 This is a catalog link folder on `main`; the complete Lean formalization is kept on the version branch.
 
+**[Open the theorem dependency map](https://optpku.github.io/ReasBook/theorem-maps/papers/tr_lalm_theory/)**
+
 **[Open the source on `v4.32.2`](https://github.com/optpku/ReasBook/tree/v4.32.2/ReasBook/Papers/TR_LALM_theory/)**
 
 - [Paper documentation](https://optpku.github.io/ReasBook/docs/TR_LALM_theory/Paper.html)
-- [Theorem dependency map](https://imathwy.github.io/ReasBook-TR_LALM/theorem-map/)

--- a/tools/theorem_map/Extract.lean
+++ b/tools/theorem_map/Extract.lean
@@ -1,0 +1,132 @@
+import Lean
+import Lean.Util.FoldConsts
+
+open Lean Core
+
+/-- A project whose compiled environment should be inspected for theorem-map data. -/
+structure ProjectSpec where
+  id : String
+  rootModule : String
+  deriving FromJson
+
+/-- Input accepted by the theorem-map environment extractor. -/
+structure ExtractConfig where
+  projects : Array ProjectSpec
+  deriving FromJson
+
+/-- Declaration metadata exported from a compiled Lean environment. -/
+structure RawDeclaration where
+  name : String
+  moduleName : String
+  line : Nat
+  kind : String
+  docString : String
+  dependencies : Array String
+  deriving ToJson
+
+/-- Environment data for one ReasBook project. -/
+structure RawProject where
+  id : String
+  rootModule : String
+  declarations : Array RawDeclaration
+  deriving ToJson
+
+/-- Whether a Lean module belongs to the requested ReasBook project. -/
+private def moduleBelongsTo (projectId : String) (moduleName : Name) : Bool :=
+  moduleName.toString.splitOn "." |>.contains projectId
+
+/-- A stable display category for a Lean constant. -/
+private def declarationKind : ConstantInfo → String
+  | .axiomInfo _ => "axiom"
+  | .defnInfo _ => "definition"
+  | .thmInfo _ => "theorem"
+  | .opaqueInfo _ => "opaque"
+  | .quotInfo _ => "quotient"
+  | .inductInfo _ => "inductive"
+  | .ctorInfo _ => "constructor"
+  | .recInfo _ => "recursor"
+
+/-- The imported module in which a declaration was compiled. -/
+private def moduleOf? (env : Environment) (declName : Name) : Option Name := do
+  let moduleIdx ← env.const2ModIdx[declName]?
+  env.allImportedModuleNames[moduleIdx.toNat]?
+
+/-- Direct constant dependencies that stay inside one ReasBook project. -/
+private def projectDependencyNames (env : Environment) (projectId : String)
+    (info : ConstantInfo) : Array String :=
+  info.getUsedConstantsAsSet.toArray.filterMap fun name => do
+    let moduleName ← moduleOf? env name
+    if moduleBelongsTo projectId moduleName then
+      some name.toString
+    else
+      none
+
+/-- Convert one environment constant to exported metadata when it belongs to a project. -/
+private def extractDeclaration? (env : Environment) (spec : ProjectSpec)
+    (name : Name) (info : ConstantInfo) : CoreM (Option RawDeclaration) := do
+  let some moduleName := moduleOf? env name
+    | return none
+  unless moduleBelongsTo spec.id moduleName do
+    return none
+  let docString := (← findDocString? env name (includeBuiltin := false)).getD ""
+  let ranges? ← findDeclarationRanges? name
+  let line := ranges?.map (·.range.pos.line) |>.getD 1
+  return some {
+    name := name.toString
+    moduleName := moduleName.toString
+    line
+    kind := declarationKind info
+    docString
+    dependencies := projectDependencyNames env spec.id info
+  }
+
+/-- Extract every imported and locally added declaration for one project. -/
+private def extractProjectCore (spec : ProjectSpec) : CoreM (Array RawDeclaration) := do
+  let env ← getEnv
+  let mut declarations := #[]
+  for (name, info) in env.constants.map₁ do
+    if let some declaration ← extractDeclaration? env spec name info then
+      declarations := declarations.push declaration
+  for (name, info) in env.constants.map₂ do
+    if let some declaration ← extractDeclaration? env spec name info then
+      declarations := declarations.push declaration
+  return declarations
+
+/-- Import a project's root module and run its metadata extraction. -/
+private unsafe def extractProject (spec : ProjectSpec) : IO RawProject := do
+  let env ← importModules #[{ module := spec.rootModule.toName }] {}
+  let context : Core.Context := {
+    fileName := "<theorem-map-extract>"
+    fileMap := default
+  }
+  let state : Core.State := { env }
+  let (declarations, _) ← CoreM.toIO (extractProjectCore spec) context state
+  return { id := spec.id, rootModule := spec.rootModule, declarations }
+
+/-- Decode an extractor configuration from JSON. -/
+private def parseConfig (path : System.FilePath) : IO ExtractConfig := do
+  let text ← IO.FS.readFile path
+  let json ← match Json.parse text with
+    | .ok value => pure value
+    | .error message => throw <| IO.userError s!"Invalid extractor JSON: {message}"
+  match fromJson? json with
+  | .ok config => pure config
+  | .error message => throw <| IO.userError s!"Invalid extractor config: {message}"
+
+/-- Export project declaration metadata as JSON for the generic theorem-map generator. -/
+unsafe def main (args : List String) : IO UInt32 := do
+  try
+    let [configPath, outputPath] := args
+      | throw <| IO.userError "Usage: Extract.lean CONFIG.json OUTPUT.json"
+    initSearchPath (← findSysroot)
+    enableInitializersExecution
+    let config ← parseConfig configPath
+    let projects ← config.projects.mapM extractProject
+    if let some parent := (outputPath : System.FilePath).parent then
+      IO.FS.createDirAll parent
+    IO.FS.writeFile outputPath (toJson projects).pretty
+    IO.println s!"Exported {projects.size} theorem-map project environments"
+    return (0 : UInt32)
+  catch error =>
+    IO.eprintln s!"theorem-map extractor failed: {error}"
+    return (1 : UInt32)

--- a/tools/theorem_map/README.md
+++ b/tools/theorem_map/README.md
@@ -1,0 +1,42 @@
+# ReasBook theorem maps
+
+This directory contains the branch-independent generator and static frontend for
+ReasBook theorem dependency maps. A map shows the natural-language statement of
+each literature-level declaration, the matching Lean declaration, and direct
+dependencies after project-internal helper declarations are contracted.
+
+## Generation
+
+`Extract.lean` reads compiled Lean environments. `generate_all.py` discovers all
+book and paper entry points on one version branch, identifies docstrings that
+begin with labels such as `Theorem 2.3`, and writes maps under:
+
+```text
+ReasBookWeb/_site/theorem-maps/books/<project-id>/
+ReasBookWeb/_site/theorem-maps/papers/<project-id>/
+```
+
+The Pages workflow checks this generator out from `main` while building every
+registered version branch. After those branch artifacts are merged,
+`catalog.py` rebuilds the cross-version map index.
+
+Run one branch locally after its Lean root modules have been compiled:
+
+```bash
+python3 tools/theorem_map/generate_all.py \
+  --repo-root . \
+  --site-root ReasBookWeb/_site \
+  --branch v4.32.2
+```
+
+## Project overrides
+
+A project can provide either of these overrides:
+
+- `theorem-map.json`: curated data rendered by the generic frontend.
+- `theorem-map/index.html`: a complete static map copied verbatim. Include a
+  `metadata.json` with `project`, `nodes`, and `edges` fields so the shared
+  catalog can report accurate counts.
+
+The static override is appropriate when an article has multiple Lean
+declarations for one numbered result or its prose requires an audited rendering.

--- a/tools/theorem_map/assets/app.js
+++ b/tools/theorem_map/assets/app.js
@@ -1,0 +1,966 @@
+(function () {
+  "use strict";
+
+  var SVG_NS = "http://www.w3.org/2000/svg";
+  var NODE_WIDTH = 146;
+  var NODE_HEIGHT = 38;
+  var LEVEL_GAP = 58;
+  var ROW_GAP = 14;
+  var MIN_ZOOM = 0.035;
+  var MAX_ZOOM = 5;
+
+  var refs = {
+    appShell: document.getElementById("appShell"),
+    sidebarToggle: document.getElementById("sidebarToggle"),
+    detailToggle: document.getElementById("detailToggle"),
+    brandMark: document.getElementById("brandMark"),
+    projectName: document.getElementById("projectName"),
+    searchInput: document.getElementById("searchInput"),
+    sectionFilter: document.getElementById("sectionFilter"),
+    typeFilter: document.getElementById("typeFilter"),
+    indexMeta: document.getElementById("indexMeta"),
+    itemList: document.getElementById("itemList"),
+    currentLabel: document.getElementById("currentLabel"),
+    currentTitle: document.getElementById("currentTitle"),
+    fullGraphButton: document.getElementById("fullGraphButton"),
+    focusGraphButton: document.getElementById("focusGraphButton"),
+    zoomOutButton: document.getElementById("zoomOutButton"),
+    fitButton: document.getElementById("fitButton"),
+    zoomInButton: document.getElementById("zoomInButton"),
+    mobileGraphButton: document.getElementById("mobileGraphButton"),
+    mobileDetailButton: document.getElementById("mobileDetailButton"),
+    workspace: document.getElementById("workspace"),
+    graphStats: document.getElementById("graphStats"),
+    graphViewport: document.getElementById("graphViewport"),
+    dependencyGraph: document.getElementById("dependencyGraph"),
+    graphScene: document.getElementById("graphScene"),
+    graphEmpty: document.getElementById("graphEmpty"),
+    legend: document.getElementById("legend"),
+    detailContent: document.getElementById("detailContent"),
+    fatalError: document.getElementById("fatalError")
+  };
+
+  var data = null;
+  var project = null;
+  var items = [];
+  var sections = [];
+  var itemById = new Map();
+  var sectionById = new Map();
+  var orderById = new Map();
+  var consumersById = new Map();
+  var preferencePrefix = "reasbook-theorem-map";
+  var state = {
+    selectedId: "",
+    graphMode: "full",
+    sidebarCollapsed: false,
+    detailCollapsed: false,
+    mobileView: "graph",
+    visibleListIds: [],
+    transform: { x: 0, y: 0, scale: 1 },
+    graphWidth: 1,
+    graphHeight: 1,
+    pointer: null
+  };
+
+  function svgElement(name, attributes) {
+    var element = document.createElementNS(SVG_NS, name);
+    Object.keys(attributes || {}).forEach(function (key) {
+      element.setAttribute(key, String(attributes[key]));
+    });
+    return element;
+  }
+
+  function readPreference(key) {
+    try {
+      return window.localStorage.getItem(preferencePrefix + ":" + key);
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function writePreference(key, value) {
+    try {
+      window.localStorage.setItem(preferencePrefix + ":" + key, value);
+    } catch (error) {
+      // Preferences are optional in private and file contexts.
+    }
+  }
+
+  function sectionMeta(sectionId) {
+    return sectionById.get(sectionId) || {
+      id: sectionId,
+      label: sectionId || "Overview",
+      short: sectionId || "Overview",
+      color: "#315fb5",
+      wash: "#e9effa"
+    };
+  }
+
+  function applySectionStyle(element, sectionId) {
+    var section = sectionMeta(sectionId);
+    element.style.setProperty("--section-color", section.color || "#315fb5");
+    element.style.setProperty("--section-wash", section.wash || "#e9effa");
+  }
+
+  function selectedItem() {
+    return itemById.get(state.selectedId) || items[0] || null;
+  }
+
+  function itemSort(leftId, rightId) {
+    return (orderById.get(leftId) || 0) - (orderById.get(rightId) || 0);
+  }
+
+  function ancestorsOf(startId) {
+    var result = new Set();
+    var start = itemById.get(startId);
+    var stack = start ? start.dependencies.slice() : [];
+    while (stack.length) {
+      var current = stack.pop();
+      if (result.has(current)) {
+        continue;
+      }
+      result.add(current);
+      var item = itemById.get(current);
+      if (item) {
+        item.dependencies.forEach(function (id) { stack.push(id); });
+      }
+    }
+    return result;
+  }
+
+  function descendantsOf(startId) {
+    var result = new Set();
+    var stack = (consumersById.get(startId) || []).slice();
+    while (stack.length) {
+      var current = stack.pop();
+      if (result.has(current)) {
+        continue;
+      }
+      result.add(current);
+      (consumersById.get(current) || []).forEach(function (id) { stack.push(id); });
+    }
+    return result;
+  }
+
+  function encodePath(path) {
+    return String(path || "")
+      .split("/")
+      .filter(Boolean)
+      .map(function (segment) { return encodeURIComponent(segment); })
+      .join("/");
+  }
+
+  function sourceUrl(item) {
+    var repository = String(project.repository || "").replace(/\/$/, "");
+    var sourceRoot = encodePath(project.sourceRoot || "");
+    var file = encodePath(item.file || "");
+    return repository + "/blob/" + encodeURIComponent(project.branch) + "/" +
+      sourceRoot + (sourceRoot ? "/" : "") + file +
+      "?plain=1#L" + Number(item.line || 1);
+  }
+
+  function moduleName(item) {
+    if (item.module) {
+      return item.module;
+    }
+    var suffix = String(item.file || "")
+      .replace(/\.lean$/, "")
+      .replace(/\//g, ".");
+    return project.id + (suffix ? "." + suffix : "");
+  }
+
+  function populateFilters() {
+    sections.forEach(function (section) {
+      var option = document.createElement("option");
+      option.value = section.id;
+      option.textContent = section.label;
+      refs.sectionFilter.appendChild(option);
+    });
+    Array.from(new Set(items.map(function (item) { return item.type; })))
+      .sort()
+      .forEach(function (type) {
+        var option = document.createElement("option");
+        option.value = type.toLowerCase();
+        option.textContent = type;
+        refs.typeFilter.appendChild(option);
+      });
+  }
+
+  function renderLegend() {
+    var fragment = document.createDocumentFragment();
+    sections.slice(0, 8).forEach(function (section) {
+      var entry = document.createElement("span");
+      var swatch = document.createElement("i");
+      swatch.className = "legend-swatch";
+      applySectionStyle(swatch, section.id);
+      entry.appendChild(swatch);
+      entry.appendChild(document.createTextNode(section.short || section.label));
+      fragment.appendChild(entry);
+    });
+    refs.legend.replaceChildren(fragment);
+  }
+
+  function listMatches(item) {
+    var needle = refs.searchInput.value.trim().toLowerCase();
+    var section = refs.sectionFilter.value;
+    var type = refs.typeFilter.value;
+    if (section !== "all" && item.section !== section) {
+      return false;
+    }
+    if (type !== "all" && item.type.toLowerCase() !== type) {
+      return false;
+    }
+    if (!needle) {
+      return true;
+    }
+    return [
+      item.label,
+      item.title,
+      item.type,
+      item.file,
+      item.declaration,
+      sectionMeta(item.section).label
+    ].join(" ").toLowerCase().indexOf(needle) >= 0;
+  }
+
+  function renderList() {
+    var visible = items.filter(listMatches);
+    var fragment = document.createDocumentFragment();
+    refs.itemList.replaceChildren();
+    state.visibleListIds = visible.map(function (item) { return item.id; });
+    refs.indexMeta.textContent = visible.length + " of " + items.length + " literature items";
+
+    if (!visible.length) {
+      var empty = document.createElement("div");
+      empty.className = "empty-list";
+      empty.textContent = "No literature items match the current filters.";
+      refs.itemList.appendChild(empty);
+      return;
+    }
+
+    sections.forEach(function (section) {
+      var sectionItems = visible.filter(function (item) {
+        return item.section === section.id;
+      });
+      if (!sectionItems.length) {
+        return;
+      }
+      var heading = document.createElement("div");
+      heading.className = "list-section-label";
+      heading.textContent = section.label;
+      fragment.appendChild(heading);
+
+      sectionItems.forEach(function (item) {
+        var row = document.createElement("button");
+        row.type = "button";
+        row.className = "item-row";
+        row.dataset.itemId = item.id;
+        row.setAttribute("role", "option");
+        row.setAttribute("aria-selected", String(item.id === state.selectedId));
+        applySectionStyle(row, item.section);
+        if (item.id === state.selectedId) {
+          row.classList.add("active");
+        }
+
+        var label = document.createElement("span");
+        label.className = "item-row-label";
+        label.textContent = item.label;
+        var copy = document.createElement("span");
+        copy.className = "item-row-copy";
+        var title = document.createElement("span");
+        title.className = "item-row-title";
+        title.textContent = item.title;
+        var declaration = document.createElement("span");
+        declaration.className = "item-row-decl";
+        declaration.textContent = item.declaration;
+        copy.appendChild(title);
+        copy.appendChild(declaration);
+        row.appendChild(label);
+        row.appendChild(copy);
+        fragment.appendChild(row);
+      });
+    });
+    refs.itemList.appendChild(fragment);
+  }
+
+  function graphVisibleIds() {
+    var section = refs.sectionFilter.value;
+    var result = new Set();
+    if (state.graphMode === "focus") {
+      if (state.selectedId) {
+        result.add(state.selectedId);
+        ancestorsOf(state.selectedId).forEach(function (id) { result.add(id); });
+        descendantsOf(state.selectedId).forEach(function (id) { result.add(id); });
+      }
+      return Array.from(result).sort(itemSort);
+    }
+    if (section === "all") {
+      return items.map(function (item) { return item.id; });
+    }
+    items.forEach(function (item) {
+      if (item.section === section) {
+        result.add(item.id);
+        ancestorsOf(item.id).forEach(function (id) { result.add(id); });
+      }
+    });
+    return Array.from(result).sort(itemSort);
+  }
+
+  function graphModel(ids) {
+    var idSet = new Set(ids);
+    var edges = [];
+    ids.forEach(function (targetId) {
+      var item = itemById.get(targetId);
+      item.dependencies.forEach(function (sourceId) {
+        if (idSet.has(sourceId)) {
+          edges.push({
+            source: sourceId,
+            target: targetId,
+            id: sourceId + "->" + targetId
+          });
+        }
+      });
+    });
+    return { ids: ids, edges: edges };
+  }
+
+  function graphLayout(ids) {
+    var idSet = new Set(ids);
+    var indegree = new Map();
+    var levels = new Map();
+    var queue = [];
+    ids.forEach(function (id) {
+      var item = itemById.get(id);
+      var degree = item.dependencies.filter(function (dependency) {
+        return idSet.has(dependency);
+      }).length;
+      indegree.set(id, degree);
+      levels.set(id, 0);
+      if (!degree) {
+        queue.push(id);
+      }
+    });
+    queue.sort(itemSort);
+    while (queue.length) {
+      var current = queue.shift();
+      (consumersById.get(current) || []).forEach(function (consumer) {
+        if (!idSet.has(consumer)) {
+          return;
+        }
+        levels.set(consumer, Math.max(levels.get(consumer) || 0, (levels.get(current) || 0) + 1));
+        indegree.set(consumer, (indegree.get(consumer) || 1) - 1);
+        if (indegree.get(consumer) === 0) {
+          queue.push(consumer);
+          queue.sort(itemSort);
+        }
+      });
+    }
+
+    var groups = new Map();
+    var maximumLevel = 0;
+    ids.forEach(function (id) {
+      var level = levels.get(id) || 0;
+      maximumLevel = Math.max(maximumLevel, level);
+      if (!groups.has(level)) {
+        groups.set(level, []);
+      }
+      groups.get(level).push(id);
+    });
+    groups.forEach(function (group) { group.sort(itemSort); });
+    var maximumRows = 1;
+    groups.forEach(function (group) { maximumRows = Math.max(maximumRows, group.length); });
+    var width = 80 + (maximumLevel + 1) * NODE_WIDTH + maximumLevel * LEVEL_GAP;
+    var height = Math.max(390, 70 + maximumRows * NODE_HEIGHT + (maximumRows - 1) * ROW_GAP);
+    var positions = new Map();
+    groups.forEach(function (group, level) {
+      var groupHeight = group.length * NODE_HEIGHT + Math.max(0, group.length - 1) * ROW_GAP;
+      var startY = Math.max(35, (height - groupHeight) / 2);
+      group.forEach(function (id, row) {
+        positions.set(id, {
+          x: 40 + level * (NODE_WIDTH + LEVEL_GAP),
+          y: startY + row * (NODE_HEIGHT + ROW_GAP)
+        });
+      });
+    });
+    return { positions: positions, width: width, height: height };
+  }
+
+  function edgePath(source, target) {
+    var startX = source.x + NODE_WIDTH;
+    var startY = source.y + NODE_HEIGHT / 2;
+    var endX = target.x;
+    var endY = target.y + NODE_HEIGHT / 2;
+    var control = Math.max(30, (endX - startX) * 0.48);
+    return "M " + startX + " " + startY + " C " +
+      (startX + control) + " " + startY + ", " +
+      (endX - control) + " " + endY + ", " + endX + " " + endY;
+  }
+
+  function renderGraph(options) {
+    var ids = graphVisibleIds();
+    var model = graphModel(ids);
+    var layout = graphLayout(ids);
+    var upstream = ancestorsOf(state.selectedId);
+    var downstream = descendantsOf(state.selectedId);
+    var edgeLayer = svgElement("g", { class: "edge-layer" });
+    var nodeLayer = svgElement("g", { class: "node-layer" });
+    refs.graphEmpty.hidden = Boolean(ids.length);
+
+    model.edges.forEach(function (edge) {
+      var source = layout.positions.get(edge.source);
+      var target = layout.positions.get(edge.target);
+      if (!source || !target) {
+        return;
+      }
+      var path = svgElement("path", {
+        class: "graph-edge",
+        d: edgePath(source, target),
+        "data-edge-id": edge.id
+      });
+      var activeUpstream = upstream.has(edge.source) &&
+        (upstream.has(edge.target) || edge.target === state.selectedId);
+      var activeDownstream = (edge.source === state.selectedId || downstream.has(edge.source)) &&
+        downstream.has(edge.target);
+      if (activeUpstream || activeDownstream) {
+        path.classList.add("active");
+      } else if (state.selectedId) {
+        path.classList.add("dim");
+      }
+      edgeLayer.appendChild(path);
+    });
+
+    ids.forEach(function (id) {
+      var item = itemById.get(id);
+      var position = layout.positions.get(id);
+      var node = svgElement("g", {
+        class: "graph-node",
+        transform: "translate(" + position.x + " " + position.y + ")",
+        tabindex: "0",
+        role: "button",
+        "aria-label": item.label + ": " + item.title,
+        "data-node-id": id
+      });
+      applySectionStyle(node, item.section);
+      if (id === state.selectedId) {
+        node.classList.add("selected");
+      } else if (upstream.has(id)) {
+        node.classList.add("upstream");
+      } else if (downstream.has(id)) {
+        node.classList.add("downstream");
+      } else if (state.selectedId) {
+        node.classList.add("dim");
+      }
+      var title = svgElement("title");
+      title.textContent = item.label + " - " + item.title;
+      var box = svgElement("rect", {
+        class: "node-box",
+        width: NODE_WIDTH,
+        height: NODE_HEIGHT,
+        rx: "5",
+        ry: "5"
+      });
+      var label = svgElement("text", {
+        class: "node-label",
+        x: NODE_WIDTH / 2,
+        y: NODE_HEIGHT / 2 + 0.5
+      });
+      label.textContent = item.label;
+      node.appendChild(title);
+      node.appendChild(box);
+      node.appendChild(label);
+      nodeLayer.appendChild(node);
+    });
+
+    refs.graphScene.replaceChildren(edgeLayer, nodeLayer);
+    state.graphWidth = layout.width;
+    state.graphHeight = layout.height;
+    refs.graphStats.innerHTML =
+      '<span class="stat-pill">' + ids.length + ' nodes</span>' +
+      '<span class="stat-pill">' + model.edges.length + ' edges</span>' +
+      '<span class="stat-pill">' + (state.graphMode === "focus" ? "neighborhood" : "full graph") + '</span>';
+    if (!options || options.fit !== false) {
+      window.requestAnimationFrame(fitGraph);
+    } else {
+      applyTransform();
+    }
+  }
+
+  function applyTransform() {
+    refs.graphScene.setAttribute(
+      "transform",
+      "translate(" + state.transform.x + " " + state.transform.y + ") " +
+        "scale(" + state.transform.scale + ")"
+    );
+  }
+
+  function fitGraph() {
+    var rect = refs.graphViewport.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) {
+      return;
+    }
+    var scale = Math.min(
+      rect.width / Math.max(state.graphWidth, 1),
+      rect.height / Math.max(state.graphHeight, 1),
+      1.45
+    );
+    scale = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, scale * 0.92));
+    state.transform.scale = scale;
+    state.transform.x = (rect.width - state.graphWidth * scale) / 2;
+    state.transform.y = (rect.height - state.graphHeight * scale) / 2;
+    applyTransform();
+  }
+
+  function zoomAt(factor, clientX, clientY) {
+    var rect = refs.graphViewport.getBoundingClientRect();
+    var pointX = clientX == null ? rect.width / 2 : clientX - rect.left;
+    var pointY = clientY == null ? rect.height / 2 : clientY - rect.top;
+    var oldScale = state.transform.scale;
+    var nextScale = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, oldScale * factor));
+    state.transform.x = pointX - (pointX - state.transform.x) * (nextScale / oldScale);
+    state.transform.y = pointY - (pointY - state.transform.y) * (nextScale / oldScale);
+    state.transform.scale = nextScale;
+    applyTransform();
+  }
+
+  function appendInline(parent, text) {
+    String(text).split(/(`[^`]*`)/g).forEach(function (part) {
+      if (part.length >= 2 && part[0] === "`" && part[part.length - 1] === "`") {
+        var code = document.createElement("code");
+        code.textContent = part.slice(1, -1);
+        parent.appendChild(code);
+      } else {
+        parent.appendChild(document.createTextNode(part));
+      }
+    });
+  }
+
+  function renderStatement(container, item) {
+    if (item.statementHtml) {
+      container.innerHTML = item.statementHtml;
+      return;
+    }
+    var statement = String(item.statement || "No natural-language statement is available.").trim();
+    var lines = statement.split(/\r?\n/);
+    var paragraph = [];
+    var list = null;
+
+    function flushParagraph() {
+      if (!paragraph.length) {
+        return;
+      }
+      var element = document.createElement("p");
+      appendInline(element, paragraph.join(" ").trim());
+      container.appendChild(element);
+      paragraph = [];
+    }
+
+    lines.forEach(function (line) {
+      var bullet = line.match(/^\s*[-*]\s+(.+)$/);
+      if (bullet) {
+        flushParagraph();
+        if (!list) {
+          list = document.createElement("ul");
+          container.appendChild(list);
+        }
+        var itemElement = document.createElement("li");
+        appendInline(itemElement, bullet[1]);
+        list.appendChild(itemElement);
+        return;
+      }
+      if (!line.trim()) {
+        flushParagraph();
+        list = null;
+        return;
+      }
+      list = null;
+      paragraph.push(line.trim());
+    });
+    flushParagraph();
+  }
+
+  function relationLink(item) {
+    var button = document.createElement("button");
+    button.type = "button";
+    button.className = "relation-link";
+    button.dataset.selectItem = item.id;
+    applySectionStyle(button, item.section);
+    var dot = document.createElement("span");
+    dot.className = "relation-dot";
+    var label = document.createElement("span");
+    label.className = "relation-label";
+    label.textContent = item.label;
+    button.appendChild(dot);
+    button.appendChild(label);
+    return button;
+  }
+
+  function relationColumn(title, ids) {
+    var column = document.createElement("div");
+    column.className = "relation-column";
+    var heading = document.createElement("h4");
+    heading.textContent = title + " (" + ids.length + ")";
+    var list = document.createElement("div");
+    list.className = "relation-list";
+    if (!ids.length) {
+      var empty = document.createElement("div");
+      empty.className = "relation-empty";
+      empty.textContent = "None at literature level.";
+      list.appendChild(empty);
+    } else {
+      ids.slice().sort(itemSort).forEach(function (id) {
+        var item = itemById.get(id);
+        if (item) {
+          list.appendChild(relationLink(item));
+        }
+      });
+    }
+    column.appendChild(heading);
+    column.appendChild(list);
+    return column;
+  }
+
+  function factRow(list, term, description) {
+    var dt = document.createElement("dt");
+    dt.textContent = term;
+    var dd = document.createElement("dd");
+    dd.textContent = description;
+    list.appendChild(dt);
+    list.appendChild(dd);
+  }
+
+  function renderDetail() {
+    var item = selectedItem();
+    if (!item) {
+      refs.detailContent.replaceChildren();
+      return;
+    }
+    var header = document.createElement("header");
+    header.className = "detail-header";
+    var kicker = document.createElement("div");
+    kicker.className = "detail-kicker";
+    var kind = document.createElement("span");
+    kind.className = "detail-kind";
+    kind.textContent = item.type;
+    var sectionTag = document.createElement("span");
+    sectionTag.className = "detail-section-tag";
+    sectionTag.textContent = sectionMeta(item.section).short || sectionMeta(item.section).label;
+    applySectionStyle(sectionTag, item.section);
+    kicker.appendChild(kind);
+    kicker.appendChild(sectionTag);
+    var heading = document.createElement("h2");
+    heading.textContent = item.label;
+    var subheading = document.createElement("p");
+    subheading.className = "detail-heading";
+    subheading.textContent = item.title;
+    var source = document.createElement("a");
+    source.className = "detail-source-link";
+    source.href = sourceUrl(item);
+    source.target = "_blank";
+    source.rel = "noreferrer";
+    var leanMark = document.createElement("span");
+    leanMark.className = "lean-mark";
+    leanMark.textContent = "LEAN";
+    source.appendChild(leanMark);
+    source.appendChild(document.createTextNode("Open source at line " + item.line));
+    header.appendChild(kicker);
+    header.appendChild(heading);
+    header.appendChild(subheading);
+    header.appendChild(source);
+
+    var statementSection = document.createElement("section");
+    statementSection.className = "detail-section";
+    var statementHeading = document.createElement("h3");
+    statementHeading.textContent = "Natural-language statement";
+    var statement = document.createElement("article");
+    statement.className = "statement";
+    renderStatement(statement, item);
+    statementSection.appendChild(statementHeading);
+    statementSection.appendChild(statement);
+
+    var relationSection = document.createElement("section");
+    relationSection.className = "detail-section";
+    var relationHeading = document.createElement("h3");
+    relationHeading.textContent = "Literature-level relations";
+    var relationGrid = document.createElement("div");
+    relationGrid.className = "relation-grid";
+    relationGrid.appendChild(relationColumn("Direct dependencies", item.dependencies));
+    relationGrid.appendChild(relationColumn("Used directly by", consumersById.get(item.id) || []));
+    relationSection.appendChild(relationHeading);
+    relationSection.appendChild(relationGrid);
+
+    var leanSection = document.createElement("section");
+    leanSection.className = "detail-section";
+    var leanHeading = document.createElement("h3");
+    leanHeading.textContent = "Lean formalization";
+    var facts = document.createElement("dl");
+    facts.className = "lean-facts";
+    factRow(facts, "Declaration", item.declaration);
+    factRow(facts, "Module", moduleName(item));
+    factRow(facts, "Source", item.file + ":" + item.line);
+    factRow(facts, "Version", project.branch);
+    factRow(facts, "Snapshot", String(project.commit || "").slice(0, 10));
+    leanSection.appendChild(leanHeading);
+    leanSection.appendChild(facts);
+    refs.detailContent.replaceChildren(header, statementSection, relationSection, leanSection);
+    refs.detailContent.parentElement.scrollTop = 0;
+  }
+
+  function renderHeader() {
+    var item = selectedItem();
+    refs.currentLabel.textContent = item ? item.label : "Theorem map";
+    refs.currentTitle.textContent = item ? item.title : project.title;
+    refs.fullGraphButton.classList.toggle("active", state.graphMode === "full");
+    refs.focusGraphButton.classList.toggle("active", state.graphMode === "focus");
+  }
+
+  function selectItem(id, options) {
+    if (!itemById.has(id)) {
+      return;
+    }
+    state.selectedId = id;
+    if (!options || options.updateHash !== false) {
+      window.history.replaceState(null, "", "#" + encodeURIComponent(id));
+    }
+    renderHeader();
+    renderList();
+    renderDetail();
+    renderGraph({ fit: false });
+    if (options && options.mobileDetail && window.innerWidth <= 820) {
+      setMobileView("detail");
+    }
+  }
+
+  function setGraphMode(mode) {
+    state.graphMode = mode === "focus" ? "focus" : "full";
+    writePreference("graph-mode", state.graphMode);
+    renderHeader();
+    renderGraph({ fit: true });
+  }
+
+  function setSidebarCollapsed(collapsed) {
+    state.sidebarCollapsed = Boolean(collapsed);
+    refs.appShell.classList.toggle("sidebar-collapsed", state.sidebarCollapsed);
+    refs.sidebarToggle.textContent = state.sidebarCollapsed ? ">" : "<";
+    refs.sidebarToggle.setAttribute("aria-expanded", String(!state.sidebarCollapsed));
+    refs.sidebarToggle.setAttribute("aria-label", state.sidebarCollapsed ? "Expand index" : "Collapse index");
+    refs.sidebarToggle.title = state.sidebarCollapsed ? "Expand index" : "Collapse index";
+    writePreference("sidebar-collapsed", String(state.sidebarCollapsed));
+    window.setTimeout(fitGraph, 170);
+  }
+
+  function setDetailCollapsed(collapsed) {
+    state.detailCollapsed = Boolean(collapsed);
+    refs.appShell.classList.toggle("detail-collapsed", state.detailCollapsed);
+    refs.detailToggle.textContent = state.detailCollapsed ? "<" : ">";
+    refs.detailToggle.setAttribute("aria-expanded", String(!state.detailCollapsed));
+    refs.detailToggle.setAttribute("aria-label", state.detailCollapsed ? "Expand statement" : "Collapse statement");
+    refs.detailToggle.title = state.detailCollapsed ? "Expand statement" : "Collapse statement";
+    writePreference("detail-collapsed", String(state.detailCollapsed));
+    window.setTimeout(fitGraph, 170);
+  }
+
+  function setMobileView(view) {
+    state.mobileView = view === "detail" ? "detail" : "graph";
+    refs.workspace.dataset.mobileView = state.mobileView;
+    refs.mobileGraphButton.classList.toggle("active", state.mobileView === "graph");
+    refs.mobileDetailButton.classList.toggle("active", state.mobileView === "detail");
+    if (state.mobileView === "graph") {
+      window.requestAnimationFrame(fitGraph);
+    }
+  }
+
+  function bindEvents() {
+    refs.sidebarToggle.addEventListener("click", function () {
+      setSidebarCollapsed(!state.sidebarCollapsed);
+    });
+    refs.detailToggle.addEventListener("click", function () {
+      setDetailCollapsed(!state.detailCollapsed);
+    });
+    refs.searchInput.addEventListener("input", renderList);
+    refs.sectionFilter.addEventListener("change", function () {
+      renderList();
+      renderGraph({ fit: true });
+    });
+    refs.typeFilter.addEventListener("change", renderList);
+    refs.itemList.addEventListener("click", function (event) {
+      var row = event.target.closest("[data-item-id]");
+      if (row) {
+        selectItem(row.dataset.itemId, { mobileDetail: true });
+      }
+    });
+    refs.itemList.addEventListener("keydown", function (event) {
+      if (event.key !== "ArrowDown" && event.key !== "ArrowUp") {
+        return;
+      }
+      event.preventDefault();
+      if (!state.visibleListIds.length) {
+        return;
+      }
+      var index = state.visibleListIds.indexOf(state.selectedId);
+      var direction = event.key === "ArrowDown" ? 1 : -1;
+      var next = (Math.max(index, 0) + direction + state.visibleListIds.length) % state.visibleListIds.length;
+      selectItem(state.visibleListIds[next], { updateHash: true });
+    });
+    refs.fullGraphButton.addEventListener("click", function () { setGraphMode("full"); });
+    refs.focusGraphButton.addEventListener("click", function () { setGraphMode("focus"); });
+    refs.zoomOutButton.addEventListener("click", function () { zoomAt(0.82); });
+    refs.zoomInButton.addEventListener("click", function () { zoomAt(1.22); });
+    refs.fitButton.addEventListener("click", fitGraph);
+    refs.mobileGraphButton.addEventListener("click", function () { setMobileView("graph"); });
+    refs.mobileDetailButton.addEventListener("click", function () { setMobileView("detail"); });
+    refs.dependencyGraph.addEventListener("click", function (event) {
+      var node = event.target.closest("[data-node-id]");
+      if (node) {
+        selectItem(node.dataset.nodeId, { mobileDetail: false });
+      }
+    });
+    refs.dependencyGraph.addEventListener("keydown", function (event) {
+      var node = event.target.closest("[data-node-id]");
+      if (node && (event.key === "Enter" || event.key === " ")) {
+        event.preventDefault();
+        selectItem(node.dataset.nodeId, { mobileDetail: false });
+      }
+    });
+    refs.detailContent.addEventListener("click", function (event) {
+      var relation = event.target.closest("[data-select-item]");
+      if (relation) {
+        selectItem(relation.dataset.selectItem, { mobileDetail: true });
+      }
+    });
+    refs.graphViewport.addEventListener("wheel", function (event) {
+      event.preventDefault();
+      zoomAt(Math.exp(-event.deltaY * 0.0012), event.clientX, event.clientY);
+    }, { passive: false });
+    refs.graphViewport.addEventListener("pointerdown", function (event) {
+      if (event.target.closest("[data-node-id]")) {
+        return;
+      }
+      event.preventDefault();
+      refs.graphViewport.setPointerCapture(event.pointerId);
+      refs.graphViewport.classList.add("dragging");
+      state.pointer = {
+        id: event.pointerId,
+        startX: event.clientX,
+        startY: event.clientY,
+        originX: state.transform.x,
+        originY: state.transform.y
+      };
+    });
+    refs.graphViewport.addEventListener("pointermove", function (event) {
+      if (!state.pointer || state.pointer.id !== event.pointerId) {
+        return;
+      }
+      state.transform.x = state.pointer.originX + event.clientX - state.pointer.startX;
+      state.transform.y = state.pointer.originY + event.clientY - state.pointer.startY;
+      applyTransform();
+    });
+    function endPointer(event) {
+      if (!state.pointer || state.pointer.id !== event.pointerId) {
+        return;
+      }
+      state.pointer = null;
+      refs.graphViewport.classList.remove("dragging");
+      if (refs.graphViewport.hasPointerCapture(event.pointerId)) {
+        refs.graphViewport.releasePointerCapture(event.pointerId);
+      }
+    }
+    refs.graphViewport.addEventListener("pointerup", endPointer);
+    refs.graphViewport.addEventListener("pointercancel", endPointer);
+    refs.graphViewport.addEventListener("dblclick", fitGraph);
+    window.addEventListener("hashchange", function () {
+      var id = decodeURIComponent(window.location.hash.replace(/^#/, ""));
+      if (itemById.has(id) && id !== state.selectedId) {
+        selectItem(id, { updateHash: false });
+      }
+    });
+    var resizeTimer = null;
+    window.addEventListener("resize", function () {
+      window.clearTimeout(resizeTimer);
+      resizeTimer = window.setTimeout(fitGraph, 100);
+    });
+  }
+
+  function validateAndLoad(payload) {
+    if (!payload || payload.schemaVersion !== 1 || !payload.project || !Array.isArray(payload.items)) {
+      throw new Error("data.json does not match theorem-map schema version 1.");
+    }
+    data = payload;
+    project = data.project;
+    preferencePrefix += ":" + String(project.id || "project");
+    items = data.items.map(function (item) {
+      return Object.assign({}, item, {
+        dependencies: Array.isArray(item.dependencies) ? item.dependencies.slice() : []
+      });
+    });
+    sections = Array.isArray(data.sections) ? data.sections.slice() : [];
+    if (!sections.length) {
+      Array.from(new Set(items.map(function (item) { return item.section || "overview"; })))
+        .forEach(function (id, index) {
+          var palette = [
+            ["#315fb5", "#e9effa"], ["#23745d", "#e4f2ed"],
+            ["#a14d3d", "#f8eae6"], ["#9a6a12", "#fbf1d8"]
+          ][index % 4];
+          sections.push({ id: id, label: id, short: id, color: palette[0], wash: palette[1] });
+        });
+    }
+    sections.forEach(function (section) { sectionById.set(section.id, section); });
+    items.forEach(function (item, index) {
+      item.section = item.section || (sections[0] && sections[0].id) || "overview";
+      itemById.set(item.id, item);
+      orderById.set(item.id, index);
+      consumersById.set(item.id, []);
+    });
+    items.forEach(function (item) {
+      item.dependencies = item.dependencies.filter(function (dependency) {
+        return itemById.has(dependency) && dependency !== item.id;
+      });
+      item.dependencies.forEach(function (dependency) {
+        consumersById.get(dependency).push(item.id);
+      });
+    });
+  }
+
+  function initialize() {
+    document.title = project.title + " - Theorem Map";
+    refs.projectName.textContent = project.title;
+    refs.brandMark.textContent = String(project.id || "RB")
+      .split(/[_\s-]+/)
+      .filter(Boolean)
+      .slice(0, 2)
+      .map(function (part) { return part[0].toUpperCase(); })
+      .join("") || "RB";
+    populateFilters();
+    renderLegend();
+    var hashId = decodeURIComponent(window.location.hash.replace(/^#/, ""));
+    state.selectedId = itemById.has(hashId) ? hashId : (items[0] ? items[0].id : "");
+    var savedMode = readPreference("graph-mode");
+    state.graphMode = savedMode === "focus" || (items.length > 320 && savedMode !== "full")
+      ? "focus" : "full";
+    state.sidebarCollapsed = readPreference("sidebar-collapsed") === "true";
+    state.detailCollapsed = readPreference("detail-collapsed") === "true";
+    setSidebarCollapsed(state.sidebarCollapsed);
+    setDetailCollapsed(state.detailCollapsed);
+    setMobileView("graph");
+    bindEvents();
+    renderHeader();
+    renderList();
+    renderDetail();
+    renderGraph({ fit: true });
+  }
+
+  fetch("./data.json", { cache: "no-cache" })
+    .then(function (response) {
+      if (!response.ok) {
+        throw new Error("Could not load data.json (HTTP " + response.status + ").");
+      }
+      return response.json();
+    })
+    .then(function (payload) {
+      validateAndLoad(payload);
+      initialize();
+    })
+    .catch(function (error) {
+      refs.fatalError.hidden = false;
+      refs.fatalError.textContent = "The theorem map could not start.\n\n" + error.message;
+    });
+}());

--- a/tools/theorem_map/assets/index.html
+++ b/tools/theorem_map/assets/index.html
@@ -1,0 +1,120 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light">
+  <meta name="description" content="Interactive theorem dependency map for a ReasBook formalization.">
+  <title>ReasBook Theorem Map</title>
+  <link rel="stylesheet" href="./styles.css">
+</head>
+<body>
+  <div class="app-shell" id="appShell">
+    <aside class="sidebar" id="sidebar">
+      <header class="brand">
+        <div class="brand-mark" id="brandMark" aria-hidden="true">RB</div>
+        <div class="brand-copy">
+          <h1>Theorem Map</h1>
+          <p id="projectName">ReasBook formalization</p>
+        </div>
+        <button class="icon-button sidebar-toggle" id="sidebarToggle" type="button"
+          title="Collapse index" aria-label="Collapse index" aria-expanded="true">&lt;</button>
+      </header>
+
+      <div class="index-controls">
+        <label class="search-field">
+          <span class="visually-hidden">Search literature items</span>
+          <input id="searchInput" type="search"
+            placeholder="Search label, title, declaration" autocomplete="off">
+        </label>
+        <div class="filter-grid">
+          <label>
+            <span>Section</span>
+            <select id="sectionFilter">
+              <option value="all">All sections</option>
+            </select>
+          </label>
+          <label>
+            <span>Kind</span>
+            <select id="typeFilter">
+              <option value="all">All kinds</option>
+            </select>
+          </label>
+        </div>
+        <div class="index-meta" id="indexMeta">Loading declarations</div>
+      </div>
+
+      <div class="item-list" id="itemList" role="listbox"
+        aria-label="Literature-level declarations" tabindex="0"></div>
+    </aside>
+
+    <main class="main-panel">
+      <header class="toolbar">
+        <div class="toolbar-title">
+          <div class="current-label" id="currentLabel">Theorem map</div>
+          <div class="current-title" id="currentTitle">Loading project data</div>
+        </div>
+        <div class="toolbar-actions">
+          <div class="segmented" role="group" aria-label="Graph scope">
+            <button id="fullGraphButton" class="active" type="button">Full graph</button>
+            <button id="focusGraphButton" type="button">Neighborhood</button>
+          </div>
+          <div class="zoom-controls" role="group" aria-label="Graph zoom">
+            <button class="icon-button" id="zoomOutButton" type="button"
+              title="Zoom out" aria-label="Zoom out">-</button>
+            <button class="icon-button fit-button" id="fitButton" type="button"
+              title="Fit graph" aria-label="Fit graph">Fit</button>
+            <button class="icon-button" id="zoomInButton" type="button"
+              title="Zoom in" aria-label="Zoom in">+</button>
+          </div>
+        </div>
+      </header>
+
+      <div class="mobile-view-switch segmented" role="group" aria-label="Mobile view">
+        <button id="mobileGraphButton" class="active" type="button">Graph</button>
+        <button id="mobileDetailButton" type="button">Statement</button>
+      </div>
+
+      <section class="workspace" id="workspace" data-mobile-view="graph">
+        <section class="graph-panel" aria-label="Theorem dependency graph">
+          <div class="graph-toolbar">
+            <div class="graph-stats" id="graphStats">Loading graph</div>
+            <div class="legend" id="legend" aria-label="Section colors"></div>
+          </div>
+          <div class="graph-viewport" id="graphViewport">
+            <svg id="dependencyGraph" class="dependency-graph"
+              role="img" aria-label="Dependency graph among literature-level declarations">
+              <defs>
+                <marker id="arrowDefault" viewBox="0 0 10 10" refX="9" refY="5"
+                  markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+                  <path d="M 0 0 L 10 5 L 0 10 z"></path>
+                </marker>
+                <marker id="arrowActive" viewBox="0 0 10 10" refX="9" refY="5"
+                  markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+                  <path d="M 0 0 L 10 5 L 0 10 z"></path>
+                </marker>
+              </defs>
+              <g id="graphScene"></g>
+            </svg>
+            <div class="graph-empty" id="graphEmpty" hidden>No graph items match this view.</div>
+          </div>
+        </section>
+
+        <aside class="detail-panel" id="detailPanel" aria-label="Selected literature item">
+          <div class="detail-rail">
+            <button class="icon-button detail-toggle" id="detailToggle" type="button"
+              title="Collapse statement" aria-label="Collapse statement"
+              aria-expanded="true">&gt;</button>
+          </div>
+          <div class="detail-scroll">
+            <div id="detailContent"></div>
+          </div>
+        </aside>
+      </section>
+    </main>
+  </div>
+
+  <div class="fatal-error" id="fatalError" hidden></div>
+  <script src="./app.js"></script>
+</body>
+</html>

--- a/tools/theorem_map/assets/styles.css
+++ b/tools/theorem_map/assets/styles.css
@@ -1,0 +1,1000 @@
+:root {
+  --ink: #1f2933;
+  --muted: #65717d;
+  --line: #d7dde3;
+  --line-strong: #bcc6cf;
+  --surface: #ffffff;
+  --surface-soft: #f5f7f8;
+  --canvas: #eef1f3;
+  --accent: #315fb5;
+  --accent-wash: #e9effa;
+  --selected: #a5630f;
+  --selected-wash: #f7e8bf;
+  --upstream: #7654a6;
+  --upstream-wash: #eee8f8;
+  --downstream: #b97819;
+  --downstream-wash: #fff0d6;
+  --shadow: 0 10px 28px rgba(25, 35, 45, 0.08);
+  color: var(--ink);
+  background: var(--canvas);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+  font-synthesis: none;
+  letter-spacing: 0;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  overflow: hidden;
+}
+
+button,
+input,
+select {
+  font: inherit;
+  letter-spacing: 0;
+}
+
+button,
+select {
+  cursor: pointer;
+}
+
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+[tabindex]:focus-visible {
+  outline: 3px solid rgba(49, 95, 181, 0.28);
+  outline-offset: 2px;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.app-shell {
+  display: grid;
+  grid-template-columns: minmax(260px, 318px) minmax(0, 1fr);
+  width: 100%;
+  height: 100%;
+  background: var(--surface);
+  transition: grid-template-columns 160ms ease;
+}
+
+.app-shell.sidebar-collapsed {
+  grid-template-columns: 54px minmax(0, 1fr);
+}
+
+.sidebar {
+  position: relative;
+  z-index: 3;
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr);
+  min-width: 0;
+  border-right: 1px solid var(--line);
+  background: var(--surface);
+  box-shadow: 5px 0 18px rgba(25, 35, 45, 0.04);
+  overflow: hidden;
+}
+
+.brand {
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr) 34px;
+  gap: 10px;
+  align-items: center;
+  min-height: 72px;
+  padding: 12px 12px 12px 14px;
+  border-bottom: 1px solid var(--line);
+}
+
+.brand-mark {
+  display: grid;
+  place-items: center;
+  width: 42px;
+  height: 42px;
+  border: 1px solid #263e58;
+  border-radius: 6px;
+  color: #ffffff;
+  background: #263e58;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.brand-copy {
+  min-width: 0;
+}
+
+.brand-copy h1 {
+  margin: 0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 19px;
+  line-height: 1.15;
+  font-weight: 700;
+}
+
+.brand-copy p {
+  margin: 4px 0 0;
+  color: var(--muted);
+  font-size: 11px;
+  line-height: 1.3;
+  overflow-wrap: anywhere;
+}
+
+.icon-button {
+  display: inline-grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  border: 1px solid var(--line-strong);
+  border-radius: 5px;
+  color: #394857;
+  background: var(--surface);
+  font-weight: 700;
+}
+
+.icon-button:hover {
+  border-color: #8e9ba7;
+  background: var(--surface-soft);
+}
+
+.sidebar-toggle {
+  justify-self: end;
+}
+
+.app-shell.sidebar-collapsed .brand {
+  grid-template-columns: 1fr;
+  padding: 10px;
+}
+
+.app-shell.sidebar-collapsed .brand-mark,
+.app-shell.sidebar-collapsed .brand-copy,
+.app-shell.sidebar-collapsed .index-controls,
+.app-shell.sidebar-collapsed .item-list {
+  display: none;
+}
+
+.app-shell.sidebar-collapsed .sidebar-toggle {
+  justify-self: center;
+}
+
+.index-controls {
+  padding: 13px 14px 11px;
+  border-bottom: 1px solid var(--line);
+  background: #fafbfc;
+}
+
+.search-field {
+  display: block;
+}
+
+.search-field input {
+  width: 100%;
+  height: 36px;
+  padding: 0 11px;
+  border: 1px solid var(--line-strong);
+  border-radius: 5px;
+  color: var(--ink);
+  background: var(--surface);
+  font-size: 13px;
+}
+
+.search-field input::placeholder {
+  color: #89949e;
+}
+
+.filter-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.filter-grid label {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.filter-grid label > span {
+  color: var(--muted);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.filter-grid select {
+  width: 100%;
+  min-width: 0;
+  height: 32px;
+  padding: 0 24px 0 8px;
+  border: 1px solid var(--line-strong);
+  border-radius: 5px;
+  color: #374553;
+  background: var(--surface);
+  font-size: 12px;
+  text-overflow: ellipsis;
+}
+
+.index-meta {
+  margin-top: 9px;
+  color: var(--muted);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.item-list {
+  min-height: 0;
+  overflow: auto;
+  scrollbar-width: thin;
+}
+
+.list-section-label {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  padding: 9px 14px 7px;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid #e9edf0;
+  color: #5e6b77;
+  background: rgba(247, 249, 250, 0.96);
+  font-size: 10px;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.list-section-label:first-child {
+  border-top: 0;
+}
+
+.item-row {
+  --section-color: var(--accent);
+  position: relative;
+  display: grid;
+  grid-template-columns: 72px minmax(0, 1fr);
+  gap: 8px;
+  width: 100%;
+  min-height: 58px;
+  padding: 9px 12px 9px 14px;
+  border: 0;
+  border-bottom: 1px solid #edf0f2;
+  color: inherit;
+  background: var(--surface);
+  text-align: left;
+}
+
+.item-row::before {
+  content: "";
+  position: absolute;
+  inset: 8px auto 8px 0;
+  width: 3px;
+  border-radius: 0 2px 2px 0;
+  background: var(--section-color);
+  opacity: 0.72;
+}
+
+.item-row:hover {
+  background: #f7f9fa;
+}
+
+.item-row.active {
+  background: #eef3f9;
+  box-shadow: inset 3px 0 0 var(--section-color);
+}
+
+.item-row-label {
+  align-self: start;
+  color: #31404e;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 10px;
+  font-weight: 800;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.item-row-copy {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+
+.item-row-title {
+  color: #273542;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+}
+
+.item-row-decl {
+  color: #74808b;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 9px;
+  line-height: 1.25;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.empty-list {
+  padding: 24px 16px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.main-panel {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  min-width: 0;
+  min-height: 0;
+  background: var(--canvas);
+}
+
+.toolbar {
+  position: relative;
+  z-index: 2;
+  display: flex;
+  gap: 18px;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 72px;
+  padding: 10px 16px 10px 20px;
+  border-bottom: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.96);
+}
+
+.toolbar-title {
+  min-width: 0;
+}
+
+.current-label {
+  color: #253544;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 19px;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.current-title {
+  max-width: 760px;
+  margin-top: 3px;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.3;
+  overflow-wrap: anywhere;
+}
+
+.toolbar-actions,
+.zoom-controls {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex: 0 0 auto;
+}
+
+.segmented {
+  display: inline-flex;
+  border: 1px solid var(--line-strong);
+  border-radius: 5px;
+  overflow: hidden;
+  background: var(--surface);
+}
+
+.segmented button {
+  min-height: 32px;
+  padding: 0 11px;
+  border: 0;
+  border-right: 1px solid var(--line-strong);
+  color: #52606d;
+  background: transparent;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.segmented button:last-child {
+  border-right: 0;
+}
+
+.segmented button:hover {
+  background: var(--surface-soft);
+}
+
+.segmented button.active {
+  color: #21457c;
+  background: var(--accent-wash);
+}
+
+.fit-button {
+  width: 42px;
+  font-size: 10px;
+}
+
+.mobile-view-switch {
+  display: none;
+}
+
+.workspace {
+  display: grid;
+  grid-template-columns: minmax(360px, 1fr) minmax(320px, 390px);
+  min-width: 0;
+  min-height: 0;
+  transition: grid-template-columns 160ms ease;
+}
+
+.app-shell.detail-collapsed .workspace {
+  grid-template-columns: minmax(360px, 1fr) 42px;
+}
+
+.graph-panel {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  min-width: 0;
+  min-height: 0;
+  background: var(--canvas);
+}
+
+.graph-toolbar {
+  display: flex;
+  gap: 14px;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 40px;
+  padding: 6px 12px;
+  border-bottom: 1px solid #d9dfe4;
+  background: #f7f8f9;
+}
+
+.graph-stats,
+.legend {
+  display: flex;
+  gap: 7px;
+  align-items: center;
+  color: #65717d;
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+}
+
+.stat-pill {
+  padding: 3px 7px;
+  border: 1px solid #d4dbe1;
+  border-radius: 4px;
+  background: #ffffff;
+}
+
+.legend {
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  max-height: 28px;
+  overflow: hidden;
+}
+
+.legend span {
+  display: inline-flex;
+  gap: 4px;
+  align-items: center;
+}
+
+.legend-swatch {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  background: var(--section-color, var(--accent));
+}
+
+.graph-viewport {
+  position: relative;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  background-color: #f1f3f4;
+  background-image: linear-gradient(#dfe4e8 1px, transparent 1px),
+    linear-gradient(90deg, #dfe4e8 1px, transparent 1px);
+  background-size: 28px 28px;
+  touch-action: none;
+  cursor: grab;
+}
+
+.graph-viewport.dragging {
+  cursor: grabbing;
+}
+
+.dependency-graph {
+  display: block;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+}
+
+.graph-edge {
+  fill: none;
+  stroke: #aab5bf;
+  stroke-width: 1.3;
+  marker-end: url(#arrowDefault);
+  transition: opacity 120ms ease, stroke 120ms ease, stroke-width 120ms ease;
+}
+
+.graph-edge.dim {
+  opacity: 0.22;
+}
+
+.graph-edge.active {
+  stroke: #315fc0;
+  stroke-width: 2.2;
+  marker-end: url(#arrowActive);
+}
+
+.graph-node {
+  --section-color: var(--accent);
+  --section-wash: var(--accent-wash);
+  cursor: pointer;
+  outline: none;
+  transition: opacity 120ms ease;
+}
+
+.graph-node.dim {
+  opacity: 0.34;
+}
+
+.graph-node .node-box {
+  fill: var(--section-wash);
+  stroke: var(--section-color);
+  stroke-width: 1.5;
+  transition: fill 120ms ease, stroke 120ms ease, stroke-width 120ms ease;
+}
+
+.graph-node:hover .node-box,
+.graph-node:focus-visible .node-box {
+  stroke-width: 2.3;
+}
+
+.graph-node.selected .node-box {
+  fill: var(--selected-wash);
+  stroke: var(--selected);
+  stroke-width: 2.7;
+}
+
+.graph-node.upstream .node-box {
+  fill: var(--upstream-wash);
+  stroke: var(--upstream);
+  stroke-width: 2.1;
+}
+
+.graph-node.downstream .node-box {
+  fill: var(--downstream-wash);
+  stroke: var(--downstream);
+  stroke-width: 2.1;
+}
+
+.node-label {
+  fill: #253544;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 10px;
+  font-weight: 700;
+  text-anchor: middle;
+  dominant-baseline: middle;
+  pointer-events: none;
+}
+
+.graph-empty {
+  position: absolute;
+  inset: 50% auto auto 50%;
+  transform: translate(-50%, -50%);
+  padding: 10px 14px;
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  color: var(--muted);
+  background: var(--surface);
+  box-shadow: var(--shadow);
+  font-size: 12px;
+}
+
+.detail-panel {
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr);
+  min-width: 0;
+  min-height: 0;
+  border-left: 1px solid var(--line);
+  background: var(--surface);
+}
+
+.detail-rail {
+  display: flex;
+  justify-content: center;
+  padding-top: 9px;
+  border-right: 1px solid #e8ecef;
+  background: #f7f8f9;
+}
+
+.detail-toggle {
+  width: 28px;
+  height: 28px;
+}
+
+.detail-scroll {
+  min-width: 0;
+  min-height: 0;
+  overflow: auto;
+}
+
+.app-shell.detail-collapsed .detail-scroll {
+  display: none;
+}
+
+.detail-header {
+  padding: 20px 20px 16px;
+  border-bottom: 1px solid var(--line);
+}
+
+.detail-kicker {
+  display: flex;
+  gap: 7px;
+  align-items: center;
+}
+
+.detail-kind,
+.detail-section-tag {
+  display: inline-flex;
+  min-height: 22px;
+  align-items: center;
+  padding: 0 7px;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  color: #53616e;
+  background: #f7f8f9;
+  font-size: 9px;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.detail-section-tag {
+  --section-color: var(--accent);
+  --section-wash: var(--accent-wash);
+  border-color: var(--section-color);
+  color: var(--section-color);
+  background: var(--section-wash);
+}
+
+.detail-header h2 {
+  margin: 13px 0 0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 24px;
+  line-height: 1.12;
+  overflow-wrap: anywhere;
+}
+
+.detail-heading {
+  margin: 7px 0 0;
+  color: #5d6b77;
+  font-size: 13px;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
+.detail-source-link {
+  display: inline-flex;
+  gap: 7px;
+  align-items: center;
+  margin-top: 13px;
+  color: #245aa8;
+  font-size: 11px;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.detail-source-link:hover {
+  text-decoration: underline;
+}
+
+.lean-mark {
+  padding: 2px 5px;
+  border-radius: 3px;
+  color: #ffffff;
+  background: #263e58;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 8px;
+}
+
+.detail-section {
+  padding: 17px 20px;
+  border-bottom: 1px solid var(--line);
+}
+
+.detail-section h3 {
+  margin: 0 0 10px;
+  color: #4a5865;
+  font-size: 10px;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.statement {
+  color: #2d3b47;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 14px;
+  line-height: 1.58;
+  overflow-wrap: anywhere;
+}
+
+.statement p {
+  margin: 0 0 10px;
+}
+
+.statement pre {
+  margin: 0;
+  white-space: pre-wrap;
+  font: inherit;
+}
+
+.statement code {
+  padding: 1px 3px;
+  border-radius: 3px;
+  background: #eef1f3;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+}
+
+.relation-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 12px;
+}
+
+.relation-column h4 {
+  margin: 0 0 7px;
+  color: #596774;
+  font-size: 10px;
+}
+
+.relation-list {
+  display: grid;
+  gap: 5px;
+}
+
+.relation-link {
+  --section-color: var(--accent);
+  display: flex;
+  gap: 7px;
+  align-items: center;
+  width: 100%;
+  min-height: 29px;
+  padding: 4px 7px;
+  border: 1px solid #dde2e6;
+  border-radius: 4px;
+  color: #354451;
+  background: #fafbfc;
+  text-align: left;
+  font-size: 10px;
+}
+
+.relation-link:hover {
+  border-color: #b8c2cb;
+  background: #f3f5f6;
+}
+
+.relation-dot {
+  flex: 0 0 auto;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--section-color);
+}
+
+.relation-label {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.relation-empty {
+  color: #8a949d;
+  font-size: 10px;
+}
+
+.lean-facts {
+  display: grid;
+  grid-template-columns: 76px minmax(0, 1fr);
+  gap: 6px 10px;
+  margin: 0;
+  font-size: 10px;
+}
+
+.lean-facts dt {
+  color: #74808a;
+  font-weight: 700;
+}
+
+.lean-facts dd {
+  min-width: 0;
+  margin: 0;
+  color: #34424f;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  overflow-wrap: anywhere;
+}
+
+.fatal-error {
+  position: fixed;
+  inset: 50% auto auto 50%;
+  z-index: 20;
+  width: min(520px, calc(100% - 32px));
+  transform: translate(-50%, -50%);
+  padding: 18px;
+  border: 1px solid #ae4c43;
+  border-radius: 6px;
+  color: #71372d;
+  background: #fff7f5;
+  box-shadow: var(--shadow);
+  font-size: 13px;
+  white-space: pre-wrap;
+}
+
+@media (max-width: 980px) {
+  .workspace {
+    grid-template-columns: minmax(320px, 1fr) minmax(290px, 340px);
+  }
+
+  .toolbar {
+    align-items: flex-start;
+  }
+
+  .toolbar-actions {
+    gap: 6px;
+  }
+
+  .legend {
+    display: none;
+  }
+}
+
+@media (max-width: 820px) {
+  html,
+  body {
+    overflow: auto;
+  }
+
+  .app-shell,
+  .app-shell.sidebar-collapsed {
+    grid-template-columns: 1fr;
+    grid-template-rows: minmax(210px, 34vh) minmax(520px, 66vh);
+    height: 100vh;
+  }
+
+  .app-shell.sidebar-collapsed {
+    grid-template-rows: 52px minmax(520px, calc(100vh - 52px));
+  }
+
+  .sidebar {
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .brand {
+    min-height: 58px;
+    grid-template-columns: 36px minmax(0, 1fr) 34px;
+  }
+
+  .brand-mark {
+    width: 36px;
+    height: 36px;
+  }
+
+  .index-controls {
+    padding-top: 9px;
+    padding-bottom: 8px;
+  }
+
+  .filter-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .main-panel {
+    grid-template-rows: auto auto minmax(0, 1fr);
+  }
+
+  .toolbar {
+    min-height: 66px;
+    padding: 9px 10px 9px 12px;
+  }
+
+  .toolbar-actions .segmented {
+    display: none;
+  }
+
+  .mobile-view-switch {
+    display: flex;
+    width: calc(100% - 20px);
+    margin: 8px 10px 0;
+  }
+
+  .mobile-view-switch button {
+    flex: 1;
+  }
+
+  .workspace,
+  .app-shell.detail-collapsed .workspace {
+    display: block;
+    min-height: 0;
+  }
+
+  .graph-panel,
+  .detail-panel {
+    height: 100%;
+  }
+
+  .workspace[data-mobile-view="graph"] .detail-panel,
+  .workspace[data-mobile-view="detail"] .graph-panel {
+    display: none;
+  }
+
+  .detail-panel {
+    grid-template-columns: 0 minmax(0, 1fr);
+    border-left: 0;
+  }
+
+  .detail-rail {
+    display: none;
+  }
+
+  .detail-scroll {
+    display: block !important;
+  }
+
+  .graph-toolbar {
+    min-height: 36px;
+  }
+
+  .relation-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 480px) {
+  .toolbar-title {
+    max-width: calc(100% - 128px);
+  }
+
+  .current-label {
+    font-size: 17px;
+  }
+
+  .current-title {
+    max-height: 32px;
+    overflow: hidden;
+  }
+
+  .zoom-controls {
+    gap: 4px;
+  }
+
+  .filter-grid {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  }
+
+  .item-row {
+    grid-template-columns: 66px minmax(0, 1fr);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/tools/theorem_map/catalog.py
+++ b/tools/theorem_map/catalog.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Rebuild the theorem-map catalog after version-branch site artifacts merge."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+from pathlib import Path
+from typing import Any
+
+
+def read_entry(map_root: Path, kind: str) -> dict[str, Any]:
+    metadata_path = map_root / "metadata.json"
+    data_path = map_root / "data.json"
+    if metadata_path.is_file():
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    elif data_path.is_file():
+        data = json.loads(data_path.read_text(encoding="utf-8"))
+        items = list(data.get("items") or [])
+        metadata = {
+            "project": data.get("project") or {},
+            "nodes": len(items),
+            "edges": sum(
+                len(item.get("dependencies") or []) for item in items
+            ),
+        }
+    else:
+        metadata = {}
+    project = metadata.get("project") or {}
+    return {
+        "title": project.get("title") or map_root.name.replace("_", " "),
+        "id": project.get("id") or map_root.name,
+        "kind": kind,
+        "slug": map_root.name,
+        "branch": project.get("branch") or "",
+        "nodes": int(metadata.get("nodes") or 0),
+        "edges": int(metadata.get("edges") or 0),
+    }
+
+
+def collect_entries(site_root: Path) -> list[dict[str, Any]]:
+    entries = []
+    maps_root = site_root / "theorem-maps"
+    for kind in ("books", "papers"):
+        kind_root = maps_root / kind
+        if not kind_root.is_dir():
+            continue
+        for map_root in sorted(kind_root.iterdir()):
+            if map_root.is_dir() and (map_root / "index.html").is_file():
+                entries.append(read_entry(map_root, kind))
+    return sorted(entries, key=lambda item: (item["kind"], item["title"].lower()))
+
+
+def write_catalog(site_root: Path) -> Path:
+    entries = collect_entries(site_root)
+    rows = []
+    for entry in entries:
+        href = f'./{entry["kind"]}/{entry["slug"]}/'
+        rows.append(
+            "      <tr>"
+            f'<td><a href="{html.escape(href)}">{html.escape(entry["title"])}</a></td>'
+            f'<td>{html.escape(entry["kind"][:-1].title())}</td>'
+            f'<td><code>{html.escape(entry["branch"])}</code></td>'
+            f'<td>{entry["nodes"]}</td><td>{entry["edges"]}</td>'
+            "</tr>"
+        )
+    catalog = site_root / "theorem-maps" / "index.html"
+    catalog.parent.mkdir(parents=True, exist_ok=True)
+    catalog.write_text(
+        "\n".join(
+            [
+                "<!doctype html>",
+                '<html lang="en">',
+                "<head>",
+                '  <meta charset="utf-8">',
+                '  <meta name="viewport" content="width=device-width,initial-scale=1">',
+                "  <title>ReasBook Theorem Maps</title>",
+                "  <style>",
+                "    :root{color-scheme:light}body{font:16px/1.5 system-ui,sans-serif;max-width:1120px;margin:40px auto;padding:0 20px;color:#1d2833;background:#f7f9fb}",
+                "    h1{letter-spacing:0}p{color:#526170}table{width:100%;border-collapse:collapse;background:#fff;border:1px solid #d8dee5}",
+                "    th,td{padding:10px 12px;border-bottom:1px solid #d8dee5;text-align:left}a{color:#245aa8}th{font-size:13px;text-transform:uppercase;color:#586675;letter-spacing:0}",
+                "    @media(max-width:720px){body{margin:20px auto}th:nth-child(3),td:nth-child(3){display:none}th,td{padding:8px}}",
+                "  </style>",
+                "</head>",
+                "<body>",
+                "  <h1>ReasBook Theorem Maps</h1>",
+                "  <p>Natural-language statements, literature-level declarations, and their Lean dependencies.</p>",
+                "  <table>",
+                "    <thead><tr><th>Project</th><th>Kind</th><th>Branch</th><th>Nodes</th><th>Edges</th></tr></thead>",
+                "    <tbody>",
+                *rows,
+                "    </tbody>",
+                "  </table>",
+                '  <p><a href="../">Back to ReasBook</a></p>',
+                "</body>",
+                "</html>",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return catalog
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--site-root", type=Path, default=Path("ReasBookWeb/_site"))
+    args = parser.parse_args()
+    catalog = write_catalog(args.site_root.resolve())
+    print(f"[theorem-map] wrote merged catalog: {catalog}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/theorem_map/generate_all.py
+++ b/tools/theorem_map/generate_all.py
@@ -1,0 +1,681 @@
+#!/usr/bin/env python3
+"""Generate theorem dependency maps for every ReasBook project on a branch.
+
+The generator reads declaration metadata from compiled Lean environments. It
+selects documentation comments that begin with a literature label (for example
+``Theorem 2.3``), chooses one representative declaration for each label, and
+contracts helper declarations when computing dependencies. Projects may ship a
+curated ``theorem-map/`` directory; that directory is copied verbatim instead.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+
+LABEL_RE = re.compile(
+    r"^\s*(?P<kind>Assumption|Algorithm|Definition|Lemma|Theorem|"
+    r"Proposition|Corollary|Remark|Example|Exercise)\s+"
+    r"(?P<number>(?:[A-Z]\.)?\d+(?:[._-]\d+)*|[A-Z](?:\.\d+)+)",
+    re.IGNORECASE,
+)
+DECL_RE = re.compile(
+    r"/--(?P<doc>.*?)\-/\s*"
+    r"(?:@\[[^\]]*\]\s*)*"
+    r"(?:noncomputable\s+|private\s+|protected\s+|public\s+|unsafe\s+)*"
+    r"(?P<kind>theorem|lemma|def|abbrev|structure|class|inductive|instance)\s+"
+    r"(?P<name>[^\s({:\[=]+)",
+    re.DOTALL,
+)
+NATURAL_PART_RE = re.compile(r"(\d+)")
+TITLE_PAREN_RE = re.compile(r"^\s*\(([^)]+)\)")
+SECTION_FILE_RE = re.compile(r"^(?:section|sec)[_-]?(\d+)", re.IGNORECASE)
+CHAPTER_RE = re.compile(r"^chap(?:ter)?[_-]?(\d+)$", re.IGNORECASE)
+
+PALETTE = [
+    ("#315fb5", "#e9effa"),
+    ("#23745d", "#e4f2ed"),
+    ("#a14d3d", "#f8eae6"),
+    ("#9a6a12", "#fbf1d8"),
+    ("#7654a6", "#eee8f8"),
+    ("#28768a", "#e2f1f4"),
+]
+
+
+@dataclass(frozen=True)
+class Project:
+    kind: str
+    kind_dir: str
+    leaf: str
+    project_id: str
+    root: Path
+    root_module: str | None
+
+    @property
+    def slug(self) -> str:
+        return self.project_id.lower()
+
+    @property
+    def source_root(self) -> str:
+        return f"ReasBook/{self.kind_dir}/{self.project_id}/"
+
+
+@dataclass
+class Candidate:
+    label: str
+    item_id: str
+    item_type: str
+    number: str
+    title: str
+    statement: str
+    declaration: str
+    declaration_kind: str
+    module_name: str
+    relative_file: str
+    line: int
+    section_id: str
+    section_label: str
+    score: float
+
+
+def natural_key(value: str) -> tuple[Any, ...]:
+    return tuple(
+        int(part) if part.isdigit() else part.lower()
+        for part in NATURAL_PART_RE.split(value)
+    )
+
+
+def slugify(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return slug or "item"
+
+
+def normalize_label(kind: str, number: str) -> tuple[str, str, str]:
+    canonical_kind = kind[0].upper() + kind[1:].lower()
+    canonical_number = number.replace("_", ".")
+    label = f"{canonical_kind} {canonical_number}"
+    return label, slugify(label), canonical_kind
+
+
+def clean_title_text(value: str) -> str:
+    value = re.sub(r"`([^`]*)`", r"\1", value)
+    value = re.sub(r"\[([^]]+)\]\([^)]+\)", r"\1", value)
+    value = re.sub(r"\s+", " ", value).strip(" :-.")
+    if len(value) > 120:
+        value = value[:117].rstrip() + "..."
+    return value
+
+
+def title_from_doc(doc: str, match: re.Match[str], label: str) -> str:
+    rest = doc[match.end() :].lstrip()
+    parenthetical = TITLE_PAREN_RE.match(rest)
+    if parenthetical:
+        proposed = clean_title_text(parenthetical.group(1))
+        if re.search(r"[A-Za-z]", proposed) and not re.fullmatch(
+            r"(?:part\s*)?[ivx\d]+", proposed, re.IGNORECASE
+        ):
+            return proposed
+        rest = rest[parenthetical.end() :].lstrip()
+    rest = rest.lstrip(":.- ")
+    first = re.split(r"\n\s*\n|(?<=[.!?])\s+", rest, maxsplit=1)[0]
+    return clean_title_text(first) or label
+
+
+def project_title(project: Project) -> str:
+    readme = project.root / "README.md"
+    if readme.is_file():
+        for line in readme.read_text(encoding="utf-8").splitlines():
+            if line.startswith("# "):
+                return line[2:].strip()
+    return project.project_id.replace("_", " ")
+
+
+def module_relative_file(project: Project, module_name: str) -> str:
+    parts = module_name.split(".")
+    try:
+        index = parts.index(project.project_id)
+    except ValueError:
+        return ""
+    suffix = parts[index + 1 :]
+    if not suffix:
+        return ""
+    candidate = Path(*suffix).with_suffix(".lean")
+    if (project.root / candidate).is_file():
+        return candidate.as_posix()
+
+    files = list(project.root.rglob(f"{suffix[-1]}.lean"))
+    expected_tail = "/".join(suffix).lower() + ".lean"
+    for file in files:
+        relative = file.relative_to(project.root).as_posix()
+        if relative.lower().endswith(expected_tail):
+            return relative
+    if len(files) == 1:
+        return files[0].relative_to(project.root).as_posix()
+    return candidate.as_posix()
+
+
+def section_for(relative_file: str, number: str) -> tuple[str, str]:
+    parts = Path(relative_file).parts
+    for part in parts:
+        chapter = CHAPTER_RE.match(part)
+        if chapter:
+            value = str(int(chapter.group(1)))
+            return f"chapter-{value}", f"Chapter {value}"
+    for part in reversed(parts):
+        section = SECTION_FILE_RE.match(Path(part).stem)
+        if section:
+            value = str(int(section.group(1)))
+            return f"section-{value}", f"Section {value}"
+    first = re.match(r"(?:[A-Z]\.)?(\d+)", number, re.IGNORECASE)
+    if first:
+        value = str(int(first.group(1)))
+        return f"section-{value}", f"Section {value}"
+    appendix = re.match(r"([A-Z])\.", number, re.IGNORECASE)
+    if appendix:
+        value = appendix.group(1).upper()
+        return f"appendix-{value.lower()}", f"Appendix {value}"
+    return "overview", "Overview"
+
+
+def candidate_score(
+    label: str,
+    item_type: str,
+    doc: str,
+    declaration_kind: str,
+    relative_file: str,
+    line: int,
+) -> float:
+    normalized_label = re.sub(r"[^a-z0-9]", "", label.lower())
+    normalized_stem = re.sub(
+        r"[^a-z0-9]", "", Path(relative_file).stem.lower()
+    )
+    score = min(len(doc), 6000) / 100.0
+    if normalized_stem == normalized_label:
+        score += 500
+    elif normalized_label in normalized_stem:
+        score += 180
+    first_paragraph = doc[:500].lower()
+    if "source-facing" in first_paragraph:
+        score += 120
+    if "main statement" in first_paragraph or "main theorem" in first_paragraph:
+        score += 60
+    if "helper" in first_paragraph or "intermediate" in first_paragraph:
+        score -= 100
+    if item_type in {"Theorem", "Lemma", "Proposition", "Corollary"} and (
+        declaration_kind in {"theorem", "opaque"}
+    ):
+        score += 30
+    score += min(line, 100000) / 1_000_000
+    return score
+
+
+def candidates_from_raw(project: Project, declarations: list[dict[str, Any]]) -> list[Candidate]:
+    candidates: list[Candidate] = []
+    for declaration in declarations:
+        doc = str(declaration.get("docString") or "").strip()
+        match = LABEL_RE.match(doc)
+        if not match:
+            continue
+        label, item_id, item_type = normalize_label(
+            match.group("kind"), match.group("number")
+        )
+        number = match.group("number").replace("_", ".")
+        module_name = str(declaration.get("moduleName") or "")
+        relative_file = module_relative_file(project, module_name)
+        line = int(declaration.get("line") or 1)
+        section_id, section_label = section_for(relative_file, number)
+        candidates.append(
+            Candidate(
+                label=label,
+                item_id=item_id,
+                item_type=item_type,
+                number=number,
+                title=title_from_doc(doc, match, label),
+                statement=doc,
+                declaration=str(declaration.get("name") or ""),
+                declaration_kind=str(declaration.get("kind") or ""),
+                module_name=module_name,
+                relative_file=relative_file,
+                line=line,
+                section_id=section_id,
+                section_label=section_label,
+                score=candidate_score(
+                    label,
+                    item_type,
+                    doc,
+                    str(declaration.get("kind") or ""),
+                    relative_file,
+                    line,
+                ),
+            )
+        )
+    return candidates
+
+
+def fallback_raw_declarations(project: Project) -> list[dict[str, Any]]:
+    declarations: list[dict[str, Any]] = []
+    for file in sorted(project.root.rglob("*.lean")):
+        text = file.read_text(encoding="utf-8")
+        relative = file.relative_to(project.root)
+        module_suffix = ".".join(relative.with_suffix("").parts)
+        module_name = f"{project.project_id}.{module_suffix}"
+        for match in DECL_RE.finditer(text):
+            line = text.count("\n", 0, match.start()) + 1
+            declarations.append(
+                {
+                    "name": match.group("name"),
+                    "moduleName": module_name,
+                    "line": line,
+                    "kind": match.group("kind"),
+                    "docString": match.group("doc").strip(),
+                    "dependencies": [],
+                }
+            )
+    return declarations
+
+
+def select_representatives(candidates: Iterable[Candidate]) -> list[Candidate]:
+    groups: dict[str, list[Candidate]] = {}
+    for candidate in candidates:
+        groups.setdefault(candidate.item_id, []).append(candidate)
+    selected = [max(group, key=lambda item: item.score) for group in groups.values()]
+    selected.sort(
+        key=lambda item: natural_key(f"{item.relative_file}:{item.line:08d}:{item.label}")
+    )
+    return selected
+
+
+def nearest_article_dependencies(
+    declaration: str,
+    raw_by_name: dict[str, dict[str, Any]],
+    selected_by_name: dict[str, str],
+) -> list[str]:
+    result: set[str] = set()
+    visited: set[str] = set()
+    stack = list(raw_by_name.get(declaration, {}).get("dependencies") or [])
+    while stack:
+        current = str(stack.pop())
+        if current in visited:
+            continue
+        visited.add(current)
+        selected = selected_by_name.get(current)
+        if selected:
+            result.add(selected)
+            continue
+        dependency = raw_by_name.get(current)
+        if dependency:
+            stack.extend(dependency.get("dependencies") or [])
+    return sorted(result, key=natural_key)
+
+
+def load_curated_manifest(project: Project) -> dict[str, Any] | None:
+    path = project.root / "theorem-map.json"
+    if not path.is_file():
+        return None
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict) or not isinstance(data.get("items"), list):
+        raise ValueError(f"Invalid theorem-map manifest: {path}")
+    return data
+
+
+def build_data(
+    project: Project,
+    raw_declarations: list[dict[str, Any]],
+    repository: str,
+    branch: str,
+    commit: str,
+) -> dict[str, Any]:
+    curated = load_curated_manifest(project)
+    if curated:
+        data = dict(curated)
+        data.setdefault("schemaVersion", 1)
+        data.setdefault("project", {})
+        data["project"].update(
+            {
+                "id": project.project_id,
+                "title": data["project"].get("title") or project_title(project),
+                "kind": project.kind,
+                "branch": branch,
+                "commit": commit,
+                "repository": repository,
+                "sourceRoot": project.source_root,
+            }
+        )
+        return data
+
+    candidates = candidates_from_raw(project, raw_declarations)
+    selected = select_representatives(candidates)
+    raw_by_name = {
+        str(item.get("name")): item
+        for item in raw_declarations
+        if item.get("name")
+    }
+    selected_by_name = {item.declaration: item.item_id for item in selected}
+    items: list[dict[str, Any]] = []
+    for candidate in selected:
+        dependencies = nearest_article_dependencies(
+            candidate.declaration, raw_by_name, selected_by_name
+        )
+        dependencies = [item for item in dependencies if item != candidate.item_id]
+        items.append(
+            {
+                "id": candidate.item_id,
+                "label": candidate.label,
+                "title": candidate.title,
+                "type": candidate.item_type,
+                "section": candidate.section_id,
+                "file": candidate.relative_file,
+                "line": candidate.line,
+                "declaration": candidate.declaration,
+                "statement": candidate.statement,
+                "dependencies": dependencies,
+            }
+        )
+
+    section_ids: list[str] = []
+    section_labels: dict[str, str] = {}
+    for candidate in selected:
+        if candidate.section_id not in section_labels:
+            section_ids.append(candidate.section_id)
+            section_labels[candidate.section_id] = candidate.section_label
+    sections = []
+    for index, section_id in enumerate(section_ids):
+        color, wash = PALETTE[index % len(PALETTE)]
+        sections.append(
+            {
+                "id": section_id,
+                "label": section_labels[section_id],
+                "short": section_labels[section_id],
+                "color": color,
+                "wash": wash,
+            }
+        )
+
+    return {
+        "schemaVersion": 1,
+        "project": {
+            "id": project.project_id,
+            "title": project_title(project),
+            "kind": project.kind,
+            "branch": branch,
+            "commit": commit,
+            "repository": repository,
+            "sourceRoot": project.source_root,
+        },
+        "sections": sections,
+        "items": items,
+        "generation": {
+            "mode": "lean-environment" if project.root_module else "source-fallback",
+            "rootModule": project.root_module or "",
+            "rawDeclarationCount": len(raw_declarations),
+        },
+    }
+
+
+def discover_root_module(repo_root: Path, project_id: str, leaf: str) -> str | None:
+    compiled = repo_root / "ReasBook" / ".lake" / "build" / "lib" / "lean"
+    if not compiled.is_dir():
+        return None
+    candidates = []
+    for path in compiled.rglob(f"{leaf}.olean"):
+        relative = path.relative_to(compiled).with_suffix("")
+        if project_id not in relative.parts:
+            continue
+        module = ".".join(relative.parts)
+        penalty = len(relative.parts)
+        if relative.parts[-2:] == (project_id, leaf):
+            penalty -= 10
+        candidates.append((penalty, module))
+    if not candidates:
+        return None
+    return min(candidates)[1]
+
+
+def discover_projects(repo_root: Path) -> list[Project]:
+    projects = []
+    for kind, kind_dir, leaf in (
+        ("books", "Books", "Book"),
+        ("papers", "Papers", "Paper"),
+    ):
+        parent = repo_root / "ReasBook" / kind_dir
+        if not parent.is_dir():
+            continue
+        for root in sorted(parent.iterdir()):
+            if not root.is_dir() or not (root / f"{leaf}.lean").is_file():
+                continue
+            projects.append(
+                Project(
+                    kind=kind,
+                    kind_dir=kind_dir,
+                    leaf=leaf,
+                    project_id=root.name,
+                    root=root,
+                    root_module=discover_root_module(repo_root, root.name, leaf),
+                )
+            )
+    return projects
+
+
+def export_environments(
+    repo_root: Path,
+    extractor: Path,
+    projects: list[Project],
+) -> dict[str, list[dict[str, Any]]]:
+    exportable = [project for project in projects if project.root_module]
+    if not exportable:
+        return {}
+    config = {
+        "projects": [
+            {"id": project.project_id, "rootModule": project.root_module}
+            for project in exportable
+        ]
+    }
+    with tempfile.TemporaryDirectory(prefix="reasbook-theorem-map-") as temp:
+        temp_root = Path(temp)
+        config_path = temp_root / "config.json"
+        output_path = temp_root / "raw.json"
+        config_path.write_text(json.dumps(config), encoding="utf-8")
+        lake = os.environ.get("LAKE_BIN") or shutil.which("lake") or "lake"
+        command = [
+            lake,
+            "env",
+            "lean",
+            "--run",
+            str(extractor.resolve()),
+            str(config_path),
+            str(output_path),
+        ]
+        subprocess.run(command, cwd=repo_root / "ReasBook", check=True)
+        payload = json.loads(output_path.read_text(encoding="utf-8"))
+    return {
+        str(project["id"]): list(project.get("declarations") or [])
+        for project in payload
+    }
+
+
+def copy_generic_map(
+    assets: Path,
+    output: Path,
+    data: dict[str, Any],
+) -> None:
+    output.mkdir(parents=True, exist_ok=True)
+    for name in ("index.html", "app.js", "styles.css"):
+        shutil.copy2(assets / name, output / name)
+    (output / "data.json").write_text(
+        json.dumps(data, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    items = list(data.get("items") or [])
+    metadata = {
+        "schemaVersion": 1,
+        "project": data.get("project") or {},
+        "nodes": len(items),
+        "edges": sum(len(item.get("dependencies") or []) for item in items),
+        "generation": data.get("generation") or {},
+    }
+    (output / "metadata.json").write_text(
+        json.dumps(metadata, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def copy_curated_map(source: Path, output: Path) -> None:
+    shutil.copytree(source, output, dirs_exist_ok=True)
+
+
+def curated_counts(source: Path) -> tuple[int, int]:
+    metadata_path = source / "metadata.json"
+    if not metadata_path.is_file():
+        return 0, 0
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    return int(metadata.get("nodes") or 0), int(metadata.get("edges") or 0)
+
+
+def write_catalog(site_root: Path, entries: list[tuple[Project, int, int]]) -> None:
+    catalog = site_root / "theorem-maps" / "index.html"
+    rows = []
+    for project, nodes, edges in entries:
+        href = f"./{project.kind}/{project.slug}/"
+        rows.append(
+            "      <tr>"
+            f'<td><a href="{html.escape(href)}">{html.escape(project_title(project))}</a></td>'
+            f"<td>{html.escape(project.kind[:-1].title())}</td>"
+            f"<td>{nodes}</td><td>{edges}</td>"
+            "</tr>"
+        )
+    catalog.parent.mkdir(parents=True, exist_ok=True)
+    catalog.write_text(
+        "\n".join(
+            [
+                "<!doctype html>",
+                '<html lang="en">',
+                "<head>",
+                '  <meta charset="utf-8">',
+                '  <meta name="viewport" content="width=device-width,initial-scale=1">',
+                "  <title>ReasBook Theorem Maps</title>",
+                "  <style>",
+                "    body{font:16px/1.5 system-ui,sans-serif;max-width:1100px;margin:40px auto;padding:0 20px;color:#1d2833}",
+                "    table{width:100%;border-collapse:collapse}th,td{padding:10px 12px;border-bottom:1px solid #d8dee5;text-align:left}",
+                "    a{color:#245aa8}th{font-size:13px;text-transform:uppercase;color:#586675}",
+                "  </style>",
+                "</head>",
+                "<body>",
+                "  <h1>ReasBook Theorem Maps</h1>",
+                "  <p>Literature-level declarations, natural-language statements, and Lean dependencies.</p>",
+                "  <table>",
+                "    <thead><tr><th>Project</th><th>Kind</th><th>Nodes</th><th>Edges</th></tr></thead>",
+                "    <tbody>",
+                *rows,
+                "    </tbody>",
+                "  </table>",
+                '  <p><a href="../">Back to ReasBook</a></p>',
+                "</body>",
+                "</html>",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def git_value(repo_root: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path("."))
+    parser.add_argument("--site-root", type=Path, default=Path("ReasBookWeb/_site"))
+    parser.add_argument("--branch", required=True)
+    parser.add_argument(
+        "--repository", default="https://github.com/optpku/ReasBook"
+    )
+    parser.add_argument(
+        "--extractor", type=Path, default=Path(__file__).with_name("Extract.lean")
+    )
+    parser.add_argument(
+        "--assets", type=Path, default=Path(__file__).with_name("assets")
+    )
+    args = parser.parse_args()
+
+    repo_root = args.repo_root.resolve()
+    site_root = (repo_root / args.site_root).resolve()
+    extractor = args.extractor.resolve()
+    assets = args.assets.resolve()
+    projects = discover_projects(repo_root)
+    if not projects:
+        print("[theorem-map] no ReasBook projects found")
+        return 0
+
+    raw_by_project: dict[str, list[dict[str, Any]]] = {}
+    try:
+        automated_projects = [
+            project
+            for project in projects
+            if not (project.root / "theorem-map" / "index.html").is_file()
+        ]
+        raw_by_project = export_environments(
+            repo_root, extractor, automated_projects
+        )
+    except subprocess.CalledProcessError as error:
+        print(
+            f"[theorem-map] Lean environment export failed ({error}); using source fallback",
+            file=sys.stderr,
+        )
+
+    commit = git_value(repo_root, "rev-parse", "HEAD")
+    entries: list[tuple[Project, int, int]] = []
+    for project in projects:
+        output = site_root / "theorem-maps" / project.kind / project.slug
+        if output.exists():
+            shutil.rmtree(output)
+        curated_static = project.root / "theorem-map"
+        if (curated_static / "index.html").is_file():
+            copy_curated_map(curated_static, output)
+            item_count, edge_count = curated_counts(curated_static)
+            print(f"[theorem-map] {project.project_id}: copied curated static map")
+        else:
+            raw = raw_by_project.get(project.project_id)
+            if raw is None:
+                raw = fallback_raw_declarations(project)
+            data = build_data(
+                project,
+                raw,
+                repository=args.repository.rstrip("/"),
+                branch=args.branch,
+                commit=commit,
+            )
+            copy_generic_map(assets, output, data)
+            item_count = len(data.get("items") or [])
+            edge_count = sum(
+                len(item.get("dependencies") or []) for item in data.get("items") or []
+            )
+            print(
+                f"[theorem-map] {project.project_id}: {item_count} nodes, {edge_count} edges"
+            )
+        entries.append((project, item_count, edge_count))
+
+    write_catalog(site_root, entries)
+    print(f"[theorem-map] generated {len(entries)} project maps")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/theorem_map/test_generate_all.py
+++ b/tools/theorem_map/test_generate_all.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Focused regression tests for theorem-map selection and dependency contraction."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import catalog
+import generate_all
+
+
+class TheoremMapTests(unittest.TestCase):
+    def test_label_normalization(self) -> None:
+        self.assertEqual(
+            generate_all.normalize_label("theorem", "A.2_3"),
+            ("Theorem A.2.3", "theorem-a-2-3", "Theorem"),
+        )
+
+    def test_hyphenated_literature_label(self) -> None:
+        match = generate_all.LABEL_RE.match(
+            "Corollary 1-11-21: a subgroup consequence."
+        )
+        self.assertIsNotNone(match)
+        self.assertEqual(match.group("number"), "1-11-21")
+
+    def test_contracts_project_helpers(self) -> None:
+        raw = {
+            "Article.main": {"dependencies": ["Internal.bridge"]},
+            "Internal.bridge": {"dependencies": ["Article.base", "Mathlib.fact"]},
+            "Article.base": {"dependencies": []},
+        }
+        selected = {
+            "Article.main": "theorem-2-2",
+            "Article.base": "lemma-2-1",
+        }
+        self.assertEqual(
+            generate_all.nearest_article_dependencies(
+                "Article.main", raw, selected
+            ),
+            ["lemma-2-1"],
+        )
+
+    def test_merged_catalog_reads_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            site_root = Path(temp)
+            map_root = site_root / "theorem-maps" / "papers" / "sample"
+            map_root.mkdir(parents=True)
+            (map_root / "index.html").write_text("<!doctype html>", encoding="utf-8")
+            (map_root / "metadata.json").write_text(
+                json.dumps(
+                    {
+                        "project": {
+                            "id": "Sample",
+                            "title": "Sample paper",
+                            "branch": "v4.32.2",
+                        },
+                        "nodes": 7,
+                        "edges": 9,
+                    }
+                ),
+                encoding="utf-8",
+            )
+            output = catalog.write_catalog(site_root)
+            rendered = output.read_text(encoding="utf-8")
+            self.assertIn("Sample paper", rendered)
+            self.assertIn("v4.32.2", rendered)
+            self.assertIn("<td>7</td><td>9</td>", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a Lean-environment exporter that reads declaration docstrings, source locations, and direct constant dependencies
- generate a responsive theorem map for every registered book and paper, with project-level curated overrides
- rebuild a cross-version theorem-map catalog after branch site artifacts merge
- add official theorem-map links to every main-branch book and paper README
- add theorem-map navigation to each independent Pages project entry

## Validation

- Extract.lean passes with Lean/mathlib v4.26.0, v4.30.0, and v4.32.2
- Python generator and catalog regression tests pass
- JavaScript, HTML, YAML, and generated JSON syntax checks pass
- generic and curated maps were assembled and served locally with core assets returning HTTP 200
- all 13 main-branch README map URLs were checked against their project slugs

Depends on #17. Merge #17 first; merging this PR then triggers the aggregated Pages deployment.