### PR TITLE
[Web] Publish only curated theorem maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Each directory in these indexes is a landing page for one book or paper. Open a 
 
 - [Books](https://github.com/optpku/ReasBook/tree/main/ReasBook/Books/)
 - [Papers](https://github.com/optpku/ReasBook/tree/main/ReasBook/Papers/)
-- [Theorem dependency maps](https://optpku.github.io/ReasBook/theorem-maps/)
+- [Theorem dependency maps](https://optpku.github.io/ReasBook/theorem-maps/) (currently TR-LALM only)
 
 ## Books
 

--- a/ReasBook/Books/AlgebraicTopology_May_1999/README.md
+++ b/ReasBook/Books/AlgebraicTopology_May_1999/README.md
@@ -2,6 +2,6 @@
 
 This is a catalog link folder on `main`; the Lean source is kept on the version branch.
 
-**[Open the theorem dependency map](https://optpku.github.io/ReasBook/theorem-maps/books/algebraictopology_may_1999/)**
+Theorem map: pending review.
 
 **[Open the source on `v4.30.0`](https://github.com/optpku/ReasBook/tree/v4.30.0/ReasBook/Books/AlgebraicTopology_May_1999/)**

--- a/ReasBook/Books/Analysis2_Tao_2022/README.md
+++ b/ReasBook/Books/Analysis2_Tao_2022/README.md
@@ -2,7 +2,7 @@
 
 This is a catalog link folder on `main`; the Lean source is available on both registered branches.
 
-**[Open the theorem dependency map](https://optpku.github.io/ReasBook/theorem-maps/books/analysis2_tao_2022/)**
+Theorem map: pending review.
 
 **[Open the source on `v4.26.0`](https://github.com/optpku/ReasBook/tree/v4.26.0/ReasBook/Books/Analysis2_Tao_2022/)**
 

--- a/ReasBook/Books/CombinatorialGroupTheory_Magnus_2004/README.md
+++ b/ReasBook/Books/CombinatorialGroupTheory_Magnus_2004/README.md
@@ -2,6 +2,6 @@
 
 This is a catalog link folder on `main`; the Lean source is kept on the version branch.
 
-**[Open the theorem dependency map](https://optpku.github.io/ReasBook/theorem-maps/books/combinatorialgrouptheory_magnus_2004/)**
+Theorem map: pending review.
 
 **[Open the source on `v4.30.0`](https://github.com/optpku/ReasBook/tree/v4.30.0/ReasBook/Books/CombinatorialGroupTheory_Magnus_2004/)**

--- a/ReasBook/Books/ConvexAnalysisMonotoneOperators_BauschkeCombettes_2017/README.md
+++ b/ReasBook/Books/ConvexAnalysisMonotoneOperators_BauschkeCombettes_2017/README.md
@@ -2,6 +2,6 @@
 
 This is a catalog link folder on `main`; the Lean source is kept on the version branch.
 
-**[Open the theorem dependency map](https://optpku.github.io/ReasBook/theorem-maps/books/convexanalysismonotoneoperators_bauschkecombettes_2017/)**
+Theorem map: pending review.
 
 **[Open the source on `v4.30.0`](https://github.com/optpku/ReasBook/tree/v4.30.0/ReasBook/Books/ConvexAnalysisMonotoneOperators_BauschkeCombettes_2017/)**

--- a/ReasBook/Books/ConvexAnalysis_Rockafellar_1970/README.md
+++ b/ReasBook/Books/ConvexAnalysis_Rockafellar_1970/README.md
@@ -2,6 +2,6 @@
 
 This is a catalog link folder on `main`; the Lean source is kept on the version branch.
 
-**[Open the theorem dependency map](https://optpku.github.io/ReasBook/theorem-maps/books/convexanalysis_rockafellar_1970/)**
+Theorem map: pending review.
 
 **[Open the source on `v4.26.0`](https://github.com/optpku/ReasBook/tree/v4.26.0/ReasBook/Books/ConvexAnalysis_Rockafellar_1970/)**

--- a/ReasBook/Books/FirstOrderMethodsOptimization_Beck_2017/README.md
+++ b/ReasBook/Books/FirstOrderMethodsOptimization_Beck_2017/README.md
@@ -2,6 +2,6 @@
 
 This is a catalog link folder on `main`; the Lean source is kept on the version branch.
 
-**[Open the theorem dependency map](https://optpku.github.io/ReasBook/theorem-maps/books/firstordermethodsoptimization_beck_2017/)**
+Theorem map: pending review.
 
 **[Open the source on `v4.30.0`](https://github.com/optpku/ReasBook/tree/v4.30.0/ReasBook/Books/FirstOrderMethodsOptimization_Beck_2017/)**

--- a/ReasBook/Books/IntegerProgramming_Conforti_2014/README.md
+++ b/ReasBook/Books/IntegerProgramming_Conforti_2014/README.md
@@ -2,6 +2,6 @@
 
 This is a catalog link folder on `main`; the Lean source is kept on the version branch.
 
-**[Open the theorem dependency map](https://optpku.github.io/ReasBook/theorem-maps/books/integerprogramming_conforti_2014/)**
+Theorem map: pending review.
 
 **[Open the source on `v4.26.0`](https://github.com/optpku/ReasBook/tree/v4.26.0/ReasBook/Books/IntegerProgramming_Conforti_2014/)**

--- a/ReasBook/Books/IntroductiontoRealAnalysisVolumeI_JiriLebl_2025/README.md
+++ b/ReasBook/Books/IntroductiontoRealAnalysisVolumeI_JiriLebl_2025/README.md
@@ -2,7 +2,7 @@
 
 This is a catalog link folder on `main`; the Lean source is available on both registered branches.
 
-**[Open the theorem dependency map](https://optpku.github.io/ReasBook/theorem-maps/books/introductiontorealanalysisvolumei_jirilebl_2025/)**
+Theorem map: pending review.
 
 **[Open the source on `v4.26.0`](https://github.com/optpku/ReasBook/tree/v4.26.0/ReasBook/Books/IntroductiontoRealAnalysisVolumeI_JiriLebl_2025/)**
 

--- a/ReasBook/Books/ProbabilityTheory_Klenke_2020/README.md
+++ b/ReasBook/Books/ProbabilityTheory_Klenke_2020/README.md
@@ -2,6 +2,6 @@
 
 This is a catalog link folder on `main`; the Lean source is kept on the version branch.
 
-**[Open the theorem dependency map](https://optpku.github.io/ReasBook/theorem-maps/books/probabilitytheory_klenke_2020/)**
+Theorem map: pending review.
 
 **[Open the source on `v4.30.0`](https://github.com/optpku/ReasBook/tree/v4.30.0/ReasBook/Books/ProbabilityTheory_Klenke_2020/)**

--- a/ReasBook/Books/README.md
+++ b/ReasBook/Books/README.md
@@ -3,15 +3,19 @@
 The `main` branch contains catalog link folders, not duplicate Lean sources.
 Open a title below and use its source link to jump to the matching version branch.
 
-| Book | Branch | Theorem map |
-| --- | --- | --- |
-| [A Concise Course in Algebraic Topology - J. Peter May (1999)](./AlgebraicTopology_May_1999/) | `v4.30.0` | [map](https://optpku.github.io/ReasBook/theorem-maps/books/algebraictopology_may_1999/) |
-| [Analysis II - Terence Tao (4th ed., 2022)](./Analysis2_Tao_2022/) | `v4.26.0`, `v4.30.0` | [map](https://optpku.github.io/ReasBook/theorem-maps/books/analysis2_tao_2022/) |
-| [Combinatorial Group Theory - Magnus, Karrass, Solitar (2004)](./CombinatorialGroupTheory_Magnus_2004/) | `v4.30.0` | [map](https://optpku.github.io/ReasBook/theorem-maps/books/combinatorialgrouptheory_magnus_2004/) |
-| [Convex Analysis - R. Tyrrell Rockafellar (1970)](./ConvexAnalysis_Rockafellar_1970/) | `v4.26.0` | [map](https://optpku.github.io/ReasBook/theorem-maps/books/convexanalysis_rockafellar_1970/) |
-| [Convex Analysis and Monotone Operator Theory - Bauschke, Combettes (2017)](./ConvexAnalysisMonotoneOperators_BauschkeCombettes_2017/) | `v4.30.0` | [map](https://optpku.github.io/ReasBook/theorem-maps/books/convexanalysismonotoneoperators_bauschkecombettes_2017/) |
-| [First-Order Methods in Optimization - Amir Beck (2017)](./FirstOrderMethodsOptimization_Beck_2017/) | `v4.30.0` | [map](https://optpku.github.io/ReasBook/theorem-maps/books/firstordermethodsoptimization_beck_2017/) |
-| [Integer Programming - Conforti, Cornuejols, Zambelli (2014)](./IntegerProgramming_Conforti_2014/) | `v4.26.0` | [map](https://optpku.github.io/ReasBook/theorem-maps/books/integerprogramming_conforti_2014/) |
-| [Introduction to Real Analysis, Volume I - Jiri Lebl (2025)](./IntroductiontoRealAnalysisVolumeI_JiriLebl_2025/) | `v4.26.0`, `v4.30.0` | [map](https://optpku.github.io/ReasBook/theorem-maps/books/introductiontorealanalysisvolumei_jirilebl_2025/) |
-| [Probability Theory - Achim Klenke (2020)](./ProbabilityTheory_Klenke_2020/) | `v4.30.0` | [map](https://optpku.github.io/ReasBook/theorem-maps/books/probabilitytheory_klenke_2020/) |
-| [Lectures on Riemann Surfaces - Otto Forster (1981)](./RiemannSurfaces_Forster_1981/) | `v4.30.0` | [map](https://optpku.github.io/ReasBook/theorem-maps/books/riemannsurfaces_forster_1981/) |
+Book theorem maps are temporarily deferred while their statements and
+dependencies are audited. The published map is currently the TR-LALM paper
+map in the papers catalog.
+
+| Book | Branch |
+| --- | --- |
+| [A Concise Course in Algebraic Topology - J. Peter May (1999)](./AlgebraicTopology_May_1999/) | `v4.30.0` |
+| [Analysis II - Terence Tao (4th ed., 2022)](./Analysis2_Tao_2022/) | `v4.26.0`, `v4.30.0` |
+| [Combinatorial Group Theory - Magnus, Karrass, Solitar (2004)](./CombinatorialGroupTheory_Magnus_2004/) | `v4.30.0` |
+| [Convex Analysis - R. Tyrrell Rockafellar (1970)](./ConvexAnalysis_Rockafellar_1970/) | `v4.26.0` |
+| [Convex Analysis and Monotone Operator Theory - Bauschke, Combettes (2017)](./ConvexAnalysisMonotoneOperators_BauschkeCombettes_2017/) | `v4.30.0` |
+| [First-Order Methods in Optimization - Amir Beck (2017)](./FirstOrderMethodsOptimization_Beck_2017/) | `v4.30.0` |
+| [Integer Programming - Conforti, Cornuejols, Zambelli (2014)](./IntegerProgramming_Conforti_2014/) | `v4.26.0` |
+| [Introduction to Real Analysis, Volume I - Jiri Lebl (2025)](./IntroductiontoRealAnalysisVolumeI_JiriLebl_2025/) | `v4.26.0`, `v4.30.0` |
+| [Probability Theory - Achim Klenke (2020)](./ProbabilityTheory_Klenke_2020/) | `v4.30.0` |
+| [Lectures on Riemann Surfaces - Otto Forster (1981)](./RiemannSurfaces_Forster_1981/) | `v4.30.0` |

--- a/ReasBook/Books/RiemannSurfaces_Forster_1981/README.md
+++ b/ReasBook/Books/RiemannSurfaces_Forster_1981/README.md
@@ -2,6 +2,6 @@
 
 This is a catalog link folder on `main`; the Lean source is kept on the version branch.
 
-**[Open the theorem dependency map](https://optpku.github.io/ReasBook/theorem-maps/books/riemannsurfaces_forster_1981/)**
+Theorem map: pending review.
 
 **[Open the source on `v4.30.0`](https://github.com/optpku/ReasBook/tree/v4.30.0/ReasBook/Books/RiemannSurfaces_Forster_1981/)**

--- a/ReasBook/Papers/OnSomeLocalRings_Maassaran_2025/README.md
+++ b/ReasBook/Papers/OnSomeLocalRings_Maassaran_2025/README.md
@@ -2,7 +2,7 @@
 
 This is a catalog link folder on `main`; the Lean source is available on both registered branches.
 
-**[Open the theorem dependency map](https://optpku.github.io/ReasBook/theorem-maps/papers/onsomelocalrings_maassaran_2025/)**
+Theorem map: pending review.
 
 **[Open the source on `v4.26.0`](https://github.com/optpku/ReasBook/tree/v4.26.0/ReasBook/Papers/OnSomeLocalRings_Maassaran_2025/)**
 

--- a/ReasBook/Papers/README.md
+++ b/ReasBook/Papers/README.md
@@ -6,5 +6,5 @@ Open a paper below and use its source link to jump to the matching version branc
 | Paper | Branch | Theorem map |
 | --- | --- | --- |
 | [A Fixed-Penalty Linearized Augmented Lagrangian Method with Classical Multiplier Updates](./TR_LALM_theory/) | `v4.32.2` | [map](https://optpku.github.io/ReasBook/theorem-maps/papers/tr_lalm_theory/) |
-| [Smooth Minimization of Non-Smooth Functions - Yurii Nesterov (2004)](./SmoothMinimization_Nesterov_2004/) | `v4.26.0`, `v4.30.0` | [map](https://optpku.github.io/ReasBook/theorem-maps/papers/smoothminimization_nesterov_2004/) |
-| [On Some Local Rings - Mohamad Maassarani (2025)](./OnSomeLocalRings_Maassaran_2025/) | `v4.26.0`, `v4.30.0` | [map](https://optpku.github.io/ReasBook/theorem-maps/papers/onsomelocalrings_maassaran_2025/) |
+| [Smooth Minimization of Non-Smooth Functions - Yurii Nesterov (2004)](./SmoothMinimization_Nesterov_2004/) | `v4.26.0`, `v4.30.0` | Pending review |
+| [On Some Local Rings - Mohamad Maassarani (2025)](./OnSomeLocalRings_Maassaran_2025/) | `v4.26.0`, `v4.30.0` | Pending review |

--- a/ReasBook/Papers/SmoothMinimization_Nesterov_2004/README.md
+++ b/ReasBook/Papers/SmoothMinimization_Nesterov_2004/README.md
@@ -2,7 +2,7 @@
 
 This is a catalog link folder on `main`; the Lean source is available on both registered branches.
 
-**[Open the theorem dependency map](https://optpku.github.io/ReasBook/theorem-maps/papers/smoothminimization_nesterov_2004/)**
+Theorem map: pending review.
 
 **[Open the source on `v4.26.0`](https://github.com/optpku/ReasBook/tree/v4.26.0/ReasBook/Papers/SmoothMinimization_Nesterov_2004/)**
 

--- a/tools/theorem_map/Extract.lean
+++ b/tools/theorem_map/Extract.lean
@@ -92,16 +92,23 @@ private def extractProjectCore (spec : ProjectSpec) : CoreM (Array RawDeclaratio
       declarations := declarations.push declaration
   return declarations
 
-/-- Import a project's root module and run its metadata extraction. -/
-private unsafe def extractProject (spec : ProjectSpec) : IO RawProject := do
-  let env ← importModules #[{ module := spec.rootModule.toName }] {}
+/-- Import all project roots once and extract each project from the shared environment. -/
+private unsafe def extractProjects (specs : Array ProjectSpec) : IO (Array RawProject) := do
+  let imports : Array Import := specs.map fun spec => {
+    module := spec.rootModule.toName
+  }
+  IO.println s!"Importing {imports.size} theorem-map project roots"
+  let env ← importModules imports {}
   let context : Core.Context := {
     fileName := "<theorem-map-extract>"
     fileMap := default
   }
   let state : Core.State := { env }
-  let (declarations, _) ← CoreM.toIO (extractProjectCore spec) context state
-  return { id := spec.id, rootModule := spec.rootModule, declarations }
+  let extractAll : CoreM (Array RawProject) := specs.mapM fun spec => do
+    let declarations ← extractProjectCore spec
+    return { id := spec.id, rootModule := spec.rootModule, declarations }
+  let (projects, _) ← CoreM.toIO extractAll context state
+  return projects
 
 /-- Decode an extractor configuration from JSON. -/
 private def parseConfig (path : System.FilePath) : IO ExtractConfig := do
@@ -121,7 +128,7 @@ unsafe def main (args : List String) : IO UInt32 := do
     initSearchPath (← findSysroot)
     enableInitializersExecution
     let config ← parseConfig configPath
-    let projects ← config.projects.mapM extractProject
+    let projects ← extractProjects config.projects
     if let some parent := (outputPath : System.FilePath).parent then
       IO.FS.createDirAll parent
     IO.FS.writeFile outputPath (toJson projects).pretty

--- a/tools/theorem_map/README.md
+++ b/tools/theorem_map/README.md
@@ -5,11 +5,15 @@ ReasBook theorem dependency maps. A map shows the natural-language statement of
 each literature-level declaration, the matching Lean declaration, and direct
 dependencies after project-internal helper declarations are contracted.
 
+The deployment currently publishes only audited, project-provided maps. This
+keeps the public site focused while the remaining books and papers are being
+reviewed. Projects without a `theorem-map/index.html` are skipped by default.
+
 ## Generation
 
 `Extract.lean` reads compiled Lean environments. `generate_all.py` discovers all
-book and paper entry points on one version branch, identifies docstrings that
-begin with labels such as `Theorem 2.3`, and writes maps under:
+book and paper entry points on one version branch and copies audited static maps
+under:
 
 ```text
 ReasBookWeb/_site/theorem-maps/books/<project-id>/
@@ -28,6 +32,10 @@ python3 tools/theorem_map/generate_all.py \
   --site-root ReasBookWeb/_site \
   --branch v4.32.2
 ```
+
+To preview automatically generated maps for the remaining projects, opt in
+explicitly with `--include-generic`. That mode identifies docstrings beginning
+with labels such as `Theorem 2.3` and extracts their Lean dependencies.
 
 ## Project overrides
 

--- a/tools/theorem_map/generate_all.py
+++ b/tools/theorem_map/generate_all.py
@@ -481,6 +481,10 @@ def export_environments(
             for project in exportable
         ]
     }
+    print(
+        f"[theorem-map] exporting {len(exportable)} compiled project environments",
+        flush=True,
+    )
     with tempfile.TemporaryDirectory(prefix="reasbook-theorem-map-") as temp:
         temp_root = Path(temp)
         config_path = temp_root / "config.json"

--- a/tools/theorem_map/generate_all.py
+++ b/tools/theorem_map/generate_all.py
@@ -467,6 +467,18 @@ def discover_projects(repo_root: Path) -> list[Project]:
     return projects
 
 
+def has_curated_map(project: Project) -> bool:
+    return (project.root / "theorem-map" / "index.html").is_file()
+
+
+def generic_projects(
+    projects: Iterable[Project], include_generic: bool
+) -> list[Project]:
+    if not include_generic:
+        return []
+    return [project for project in projects if not has_curated_map(project)]
+
+
 def export_environments(
     repo_root: Path,
     extractor: Path,
@@ -617,6 +629,11 @@ def main() -> int:
     parser.add_argument(
         "--assets", type=Path, default=Path(__file__).with_name("assets")
     )
+    parser.add_argument(
+        "--include-generic",
+        action="store_true",
+        help="also generate maps from Lean environments for projects without a curated map",
+    )
     args = parser.parse_args()
 
     repo_root = args.repo_root.resolve()
@@ -628,34 +645,33 @@ def main() -> int:
         print("[theorem-map] no ReasBook projects found")
         return 0
 
+    maps_root = site_root / "theorem-maps"
+    if maps_root.exists():
+        shutil.rmtree(maps_root)
+
     raw_by_project: dict[str, list[dict[str, Any]]] = {}
-    try:
-        automated_projects = [
-            project
-            for project in projects
-            if not (project.root / "theorem-map" / "index.html").is_file()
-        ]
-        raw_by_project = export_environments(
-            repo_root, extractor, automated_projects
-        )
-    except subprocess.CalledProcessError as error:
-        print(
-            f"[theorem-map] Lean environment export failed ({error}); using source fallback",
-            file=sys.stderr,
-        )
+    if args.include_generic:
+        try:
+            automated_projects = generic_projects(projects, args.include_generic)
+            raw_by_project = export_environments(
+                repo_root, extractor, automated_projects
+            )
+        except subprocess.CalledProcessError as error:
+            print(
+                f"[theorem-map] Lean environment export failed ({error}); using source fallback",
+                file=sys.stderr,
+            )
 
     commit = git_value(repo_root, "rev-parse", "HEAD")
     entries: list[tuple[Project, int, int]] = []
     for project in projects:
         output = site_root / "theorem-maps" / project.kind / project.slug
-        if output.exists():
-            shutil.rmtree(output)
         curated_static = project.root / "theorem-map"
-        if (curated_static / "index.html").is_file():
+        if has_curated_map(project):
             copy_curated_map(curated_static, output)
             item_count, edge_count = curated_counts(curated_static)
             print(f"[theorem-map] {project.project_id}: copied curated static map")
-        else:
+        elif args.include_generic:
             raw = raw_by_project.get(project.project_id)
             if raw is None:
                 raw = fallback_raw_declarations(project)
@@ -674,10 +690,16 @@ def main() -> int:
             print(
                 f"[theorem-map] {project.project_id}: {item_count} nodes, {edge_count} edges"
             )
+        else:
+            print(
+                f"[theorem-map] {project.project_id}: skipped (no curated static map)"
+            )
+            continue
         entries.append((project, item_count, edge_count))
 
     write_catalog(site_root, entries)
-    print(f"[theorem-map] generated {len(entries)} project maps")
+    mode = "curated plus generic" if args.include_generic else "curated only"
+    print(f"[theorem-map] generated {len(entries)} project maps ({mode})")
     return 0
 
 

--- a/tools/theorem_map/test_generate_all.py
+++ b/tools/theorem_map/test_generate_all.py
@@ -46,6 +46,36 @@ class TheoremMapTests(unittest.TestCase):
             ["lemma-2-1"],
         )
 
+    def test_generic_projects_are_opt_in(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            curated_root = root / "curated"
+            generated_root = root / "generated"
+            (curated_root / "theorem-map").mkdir(parents=True)
+            (curated_root / "theorem-map" / "index.html").write_text(
+                "<!doctype html>", encoding="utf-8"
+            )
+            curated = generate_all.Project(
+                kind="papers",
+                kind_dir="Papers",
+                leaf="Paper",
+                project_id="Curated",
+                root=curated_root,
+                root_module=None,
+            )
+            generated = generate_all.Project(
+                kind="books",
+                kind_dir="Books",
+                leaf="Book",
+                project_id="Generated",
+                root=generated_root,
+                root_module="Generated.Book",
+            )
+            self.assertEqual(generate_all.generic_projects([curated, generated], False), [])
+            self.assertEqual(
+                generate_all.generic_projects([curated, generated], True), [generated]
+            )
+
     def test_merged_catalog_reads_metadata(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             site_root = Path(temp)


### PR DESCRIPTION
The first cross-version theorem-map deployment timed out while exporting the ten v4.30.0 projects. For the current rollout, only audited project-provided maps should be published: this means TR-LALM on v4.32.2, while all other books and papers are skipped.

This change makes curated-only generation the default and keeps Lean-environment extraction behind the explicit --include-generic flag for a later rollout. The extractor also imports all requested roots once when that opt-in mode is used. Catalog READMEs retain only the TR-LALM map URL; every other project is marked pending review instead of linking to an unpublished map.

Validation:
- Python theorem-map unit tests pass (5 tests)
- Curated-only smoke test produces exactly one TR-LALM map (24 nodes, 42 edges)
- Only the two intended TR-LALM README entries contain project-map URLs
- Extract.lean elaborates with Lean v4.26.0, v4.30.0, and v4.32.2
- Existing Pages failure: https://github.com/optpku/ReasBook/actions/runs/31460740993