### PR TITLE
[README] Document single-project checkout and licensing

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -174,3 +174,28 @@
       of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,39 @@ Each directory in these indexes is a landing page for one book or paper. Open a 
 - [Papers](https://github.com/optpku/ReasBook/tree/main/ReasBook/Papers/)
 - [Theorem dependency maps](https://optpku.github.io/ReasBook/theorem-maps/) (currently TR-LALM only)
 
+## Download and Use One Project
+
+You do not need to download every ReasBook project or the history of every
+toolchain branch. First find the book or paper in the tables below and note its
+version branch and project directory. A single-branch sparse checkout can then
+download the shared Lean project files and only the selected source directory.
+
+For example, to use *First-Order Methods in Optimization* from `v4.30.0`:
+
+```bash
+git clone --depth 1 --filter=blob:none --no-checkout --single-branch \
+  --branch v4.30.0 https://github.com/optpku/ReasBook.git
+cd ReasBook
+git sparse-checkout init --no-cone
+git sparse-checkout set \
+  '/ReasBook/lakefile.lean' \
+  '/ReasBook/lean-toolchain' \
+  '/ReasBook/lake-manifest.json' \
+  '/ReasBook/Books/FirstOrderMethodsOptimization_Beck_2017/**'
+git checkout v4.30.0
+cd ReasBook
+lake exe cache get
+lake env lean Books/FirstOrderMethodsOptimization_Beck_2017/Book.lean
+```
+
+Replace the branch, `Books`/`Papers` directory, project identifier, and Lake
+root file with those of the selected entry (`Book.lean` for a book and
+`Paper.lean` for a paper). Sparse checkout avoids downloading the other
+ReasBook sources on that branch; Lake still downloads the required mathlib
+dependencies and compiled cache. A normal clone of this repository can fetch
+all official version branches, but it does not include independent repositories
+in GitHub's forks network.
+
 ## Books
 
 | Book | Branch | Contributors | Documentation | Source | Verso |
@@ -151,4 +184,8 @@ python3 serve.py 18000     # serve at http://127.0.0.1:18000/ReasBook/
 
 ## License
 
-Released under the Apache 2.0 license. See `LICENSE` for details.
+ReasBook uses the [Apache License 2.0](LICENSE), matching mathlib. Unless an
+individual file carries a different notice, this license covers ReasBook
+content on every official branch and in all copies and forks derived from this
+repository. Fork-specific additions and third-party dependencies remain subject
+to their respective license notices.


### PR DESCRIPTION
Adds a tested single-project download workflow to the main README:\n\n- Uses a shallow, single-branch sparse checkout, so users fetch only the selected book/paper plus shared Lake configuration\n- Shows how to fetch mathlib cache and check the selected root file\n- Clarifies that ordinary clones can fetch all official branches but do not include independent GitHub fork repositories\n- States that ReasBook uses Apache License 2.0 across official branches and derived copies/forks, subject to per-file and third-party notices\n- Restores the standard Apache appendix so LICENSE exactly matches mathlib's current LICENSE\n\nValidation:\n- Ran the documented checkout against optpku/ReasBook v4.30.0\n- The selected First-Order Methods root was present; an unrelated book root was absent\n- Sparse checkout used about 12 MB before Lake dependencies/cache\n- ReasBook and mathlib LICENSE files have identical SHA-256 hashes