### PR TITLE
[README] Add M2F and ReasBook citation metadata

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,30 @@
+cff-version: 1.2.0
+message: >-
+  If you use ReasBook, cite the M2F paper and this repository, and identify the
+  project directory, version branch, and full commit SHA used.
+title: "ReasBook: Formalizations of Mathematical Textbooks and Research Papers in Lean 4"
+type: software
+authors:
+  - name: "ReasBook Contributors"
+repository-code: "https://github.com/optpku/ReasBook"
+url: "https://github.com/optpku/ReasBook"
+license: Apache-2.0
+references:
+  - type: article
+    authors:
+      - family-names: Wang
+        given-names: Zichen
+      - family-names: Ma
+        given-names: Wanli
+      - family-names: Ming
+        given-names: Zhenyu
+      - family-names: Zhang
+        given-names: Gong
+      - family-names: Yuan
+        given-names: Kun
+      - family-names: Wen
+        given-names: Zaiwen
+    title: "M2F: Automated Formalization of Mathematical Literature at Scale"
+    year: 2026
+    doi: "10.48550/arXiv.2602.17016"
+    url: "https://arxiv.org/abs/2602.17016"

--- a/README.md
+++ b/README.md
@@ -182,6 +182,45 @@ python3 serve.py 18000     # serve at http://127.0.0.1:18000/ReasBook/
 - Zaiwen Wen, Beijing International Center for Mathematical Research, Peking University, China (`wenzw@pku.edu.cn`)
 - Yifan Bai, Anjie Dong, Yunxi Duan, Xinyi Guo, Pengfei Hao, Yuhao Jiang, Gongxun Li, Yantao Li, Wentao Long, Zebo Liu, Zhenxi Liu, Siyuan Ma, Guangxuan Pan, Siyuan Shao, Weiran Shi, Junren Si, Xuran Sun, Xuan Tang, Feiming Wang, Yijie Wang, Zhiyan Wang, Zixi Wang, Suwu Wu, Mingyue Xu, Lurong Yang, Yunfei Zhang, Jian Yu, Changyun Zou
 
+## Citation
+
+If you use ReasBook, please cite both the M2F paper and the repository:
+
+M2F paper:
+
+```bibtex
+@misc{wang2026m2f,
+  author        = {Zichen Wang and Wanli Ma and Zhenyu Ming and Gong Zhang and
+                   Kun Yuan and Zaiwen Wen},
+  title         = {{M2F}: Automated Formalization of Mathematical Literature at Scale},
+  year          = {2026},
+  eprint        = {2602.17016},
+  archivePrefix = {arXiv},
+  primaryClass  = {cs.AI},
+  doi           = {10.48550/arXiv.2602.17016},
+  url           = {https://arxiv.org/abs/2602.17016}
+}
+```
+
+ReasBook software:
+
+```bibtex
+@software{reasbook2026,
+  author  = {{ReasBook Contributors}},
+  title   = {{ReasBook}: Formalizations of Mathematical Textbooks and
+             Research Papers in {Lean 4}},
+  year    = {2026},
+  url     = {https://github.com/optpku/ReasBook},
+  license = {Apache-2.0}
+}
+```
+
+When referring to a particular formalization, also cite the original book or
+paper and record the ReasBook project directory, version branch, and full commit
+SHA. For example: `v4.30.0`, `ReasBook/Books/<project>/`, and the output of
+`git rev-parse HEAD`. This repository also provides [`CITATION.cff`](CITATION.cff)
+for citation tools and GitHub's citation interface.
+
 ## License
 
 ReasBook uses the [Apache License 2.0](LICENSE), matching mathlib. Unless an


### PR DESCRIPTION
## Summary

- add the official M2F paper BibTeX citation to the root README
- add a software citation for ReasBook
- add a schema-valid `CITATION.cff` with the M2F paper as a related reference
- document how to identify a formalization by directory, version branch, and commit SHA

## Validation

- validated `CITATION.cff` against the official Citation File Format 1.2.0 JSON schema
- checked the M2F metadata against arXiv:2602.17016
- ran `git diff --check`