### PR TITLE
[Paper][v4.32.2] Align stochastic admissibility hypotheses

### DIFF
--- a/ReasBook/Papers/TR_LALM_theory/Lemma_3_4.lean
+++ b/ReasBook/Papers/TR_LALM_theory/Lemma_3_4.lean
@@ -1905,9 +1905,10 @@ private lemma integrableGradientErrorSquare
   exact Integrable.mono' (integrable_const _)
     hsquareMeasurable (ae_of_all ℙ hbound)
 
-/-- Lemma 3.4 (4): on an admissible prefix of length at least two, accumulated
-step mean square is bounded by the initial allowance and accumulated error. -/
-theorem accumulatedStepMeanSquare_le
+/-- Pointwise form of Lemma 3.4 (4): on an admissible prefix of length at least
+two, accumulated step mean square is bounded by the initial allowance and
+accumulated error. -/
+theorem accumulatedStepMeanSquare_le_of_isAdmissiblePrefix
     (K : ℕ) (hK : 2 ≤ K) (h_admissible : run.IsAdmissiblePrefix K) :
     ∑ k ∈ Finset.range K, run.stepMeanSquare k ≤
       initialStepBound h params + errorStepConstant h params *
@@ -2035,9 +2036,10 @@ private lemma errorStepBatchCoefficient_le_half
           oracle.meanSquareLipschitz ^ 2) / (b : ℝ)) / 2 := by ring
     _ ≤ (1 : ℝ) / 2 := div_le_div_of_nonneg_right hdivided htwoNonneg
 
-/-- Lemma 3.4 (5): under `SPIDER.IsSufficientInnerBatchSize`, the average
-projected-gradient-error mean square has the stated variance and initial terms. -/
-theorem averageGradientErrorMeanSquare_le
+/-- Pointwise form of Lemma 3.4 (5): under
+`SPIDER.IsSufficientInnerBatchSize`, the average projected-gradient-error mean
+square has the stated variance and initial terms. -/
+theorem averageGradientErrorMeanSquare_le_of_isAdmissiblePrefix
     (K : ℕ) (hK : 2 ≤ K) (h_admissible : run.IsAdmissiblePrefix K)
     (h_batch : SPIDER.IsSufficientInnerBatchSize h oracle params Q b) :
     (∑ k ∈ Finset.range K, run.gradientErrorMeanSquare k) / K ≤
@@ -2045,7 +2047,8 @@ theorem averageGradientErrorMeanSquare_le
         initialStepBound h params / (errorStepConstant h params * K) := by
   have hspider := run.accumulatedGradientErrorMeanSquare_le K h_admissible.isAE
     (fun k hk ↦ integrableStepSquare run h_admissible hk)
-  have hsteps := run.accumulatedStepMeanSquare_le K hK h_admissible
+  have hsteps :=
+    run.accumulatedStepMeanSquare_le_of_isAdmissiblePrefix K hK h_admissible
   have habsorb := errorStepBatchCoefficient_le_half h oracle params Q b h_batch
   have hDpos := errorStepConstant_pos h params
   have hDzero : errorStepConstant h params ≠ 0 := hDpos.ne'
@@ -2150,17 +2153,20 @@ theorem averageGradientErrorMeanSquare_le
         initialStepBound h params / (errorStepConstant h params * K)) * K := by
       field_simp [hDzero]
 
-/-- Lemma 3.4 (6): under `SPIDER.IsSufficientInnerBatchSize`, the average primal
-step mean square has the stated variance and initial terms. -/
-theorem averageStepMeanSquare_le
+/-- Pointwise form of Lemma 3.4 (6): under
+`SPIDER.IsSufficientInnerBatchSize`, the average primal step mean square has the
+stated variance and initial terms. -/
+theorem averageStepMeanSquare_le_of_isAdmissiblePrefix
     (K : ℕ) (hK : 2 ≤ K) (h_admissible : run.IsAdmissiblePrefix K)
     (h_batch : SPIDER.IsSufficientInnerBatchSize h oracle params Q b) :
     (∑ k ∈ Finset.range K, run.stepMeanSquare k) / K ≤
       2 * errorStepConstant h params * oracle.noiseLevel ^ 2 / B +
         2 * initialStepBound h params / K := by
-  have hsteps := run.accumulatedStepMeanSquare_le K hK h_admissible
+  have hsteps :=
+    run.accumulatedStepMeanSquare_le_of_isAdmissiblePrefix K hK h_admissible
   have herrors :=
-    run.averageGradientErrorMeanSquare_le K hK h_admissible h_batch
+    run.averageGradientErrorMeanSquare_le_of_isAdmissiblePrefix K hK
+      h_admissible h_batch
   have hDpos := errorStepConstant_pos h params
   have hDzero : errorStepConstant h params ≠ 0 := hDpos.ne'
   have hKreal : 0 < (K : ℝ) := by positivity
@@ -2206,6 +2212,75 @@ theorem averageStepMeanSquare_le
       add_le_add (le_refl _) herrorsScaled
     _ = 2 * errorStepConstant h params * oracle.noiseLevel ^ 2 / B +
         2 * initialStepBound h params / K := by ring
+
+/-- Lemma 3.4 (4): on an almost-surely admissible prefix of length at least two,
+accumulated step mean square is bounded by the initial allowance and accumulated
+error. -/
+theorem accumulatedStepMeanSquare_le
+    (K : ℕ) (hK : 2 ≤ K) (h_admissible : run.IsAEAdmissiblePrefix K) :
+    ∑ k ∈ Finset.range K, run.stepMeanSquare k ≤
+      initialStepBound h params + errorStepConstant h params *
+        ∑ k ∈ Finset.range K, run.gradientErrorMeanSquare k := by
+  obtain ⟨run', hrun'_admissible, _hpoint, _hmultiplier, hstep, herror⟩ :=
+    h_admissible.exists_pathwiseVersion run K
+  have hstepMeanSquare (k : ℕ) :
+      run'.stepMeanSquare k = run.stepMeanSquare k := by
+    rw [run'.stepMeanSquare_def, run.stepMeanSquare_def]
+    exact integral_congr_ae ((hstep k).fun_comp fun p ↦ ‖p‖ ^ 2)
+  have herrorMeanSquare (k : ℕ) :
+      run'.gradientErrorMeanSquare k = run.gradientErrorMeanSquare k := by
+    rw [run'.gradientErrorMeanSquare_def, run.gradientErrorMeanSquare_def]
+    exact integral_congr_ae ((herror k).fun_comp fun e ↦ ‖e‖ ^ 2)
+  have hbound := run'.accumulatedStepMeanSquare_le_of_isAdmissiblePrefix K hK
+    hrun'_admissible
+  simpa only [hstepMeanSquare, herrorMeanSquare] using hbound
+
+/-- Lemma 3.4 (5): on an almost-surely admissible prefix and under
+`SPIDER.IsSufficientInnerBatchSize`, the average projected-gradient-error mean
+square has the stated variance and initial terms. -/
+theorem averageGradientErrorMeanSquare_le
+    (K : ℕ) (hK : 2 ≤ K) (h_admissible : run.IsAEAdmissiblePrefix K)
+    (h_batch : SPIDER.IsSufficientInnerBatchSize h oracle params Q b) :
+    (∑ k ∈ Finset.range K, run.gradientErrorMeanSquare k) / K ≤
+      2 * oracle.noiseLevel ^ 2 / B +
+        initialStepBound h params / (errorStepConstant h params * K) := by
+  obtain ⟨run', hrun'_admissible, _hpoint, _hmultiplier, hstep, herror⟩ :=
+    h_admissible.exists_pathwiseVersion run K
+  have hstepMeanSquare (k : ℕ) :
+      run'.stepMeanSquare k = run.stepMeanSquare k := by
+    rw [run'.stepMeanSquare_def, run.stepMeanSquare_def]
+    exact integral_congr_ae ((hstep k).fun_comp fun p ↦ ‖p‖ ^ 2)
+  have herrorMeanSquare (k : ℕ) :
+      run'.gradientErrorMeanSquare k = run.gradientErrorMeanSquare k := by
+    rw [run'.gradientErrorMeanSquare_def, run.gradientErrorMeanSquare_def]
+    exact integral_congr_ae ((herror k).fun_comp fun e ↦ ‖e‖ ^ 2)
+  have hbound :=
+    run'.averageGradientErrorMeanSquare_le_of_isAdmissiblePrefix K hK
+      hrun'_admissible h_batch
+  simpa only [hstepMeanSquare, herrorMeanSquare] using hbound
+
+/-- Lemma 3.4 (6): on an almost-surely admissible prefix and under
+`SPIDER.IsSufficientInnerBatchSize`, the average primal step mean square has the
+stated variance and initial terms. -/
+theorem averageStepMeanSquare_le
+    (K : ℕ) (hK : 2 ≤ K) (h_admissible : run.IsAEAdmissiblePrefix K)
+    (h_batch : SPIDER.IsSufficientInnerBatchSize h oracle params Q b) :
+    (∑ k ∈ Finset.range K, run.stepMeanSquare k) / K ≤
+      2 * errorStepConstant h params * oracle.noiseLevel ^ 2 / B +
+        2 * initialStepBound h params / K := by
+  obtain ⟨run', hrun'_admissible, _hpoint, _hmultiplier, hstep, herror⟩ :=
+    h_admissible.exists_pathwiseVersion run K
+  have hstepMeanSquare (k : ℕ) :
+      run'.stepMeanSquare k = run.stepMeanSquare k := by
+    rw [run'.stepMeanSquare_def, run.stepMeanSquare_def]
+    exact integral_congr_ae ((hstep k).fun_comp fun p ↦ ‖p‖ ^ 2)
+  have herrorMeanSquare (k : ℕ) :
+      run'.gradientErrorMeanSquare k = run.gradientErrorMeanSquare k := by
+    rw [run'.gradientErrorMeanSquare_def, run.gradientErrorMeanSquare_def]
+    exact integral_congr_ae ((herror k).fun_comp fun e ↦ ‖e‖ ^ 2)
+  have hbound := run'.averageStepMeanSquare_le_of_isAdmissiblePrefix K hK
+    hrun'_admissible h_batch
+  simpa only [hstepMeanSquare, herrorMeanSquare] using hbound
 
 end LALM.StochasticRun
 

--- a/ReasBook/Papers/TR_LALM_theory/Lemma_3_5.lean
+++ b/ReasBook/Papers/TR_LALM_theory/Lemma_3_5.lean
@@ -1259,10 +1259,10 @@ private lemma constraintNormSq_eq_multiplierIncrementNormSqDiv
   rw [hupdate, add_sub_cancel_left, norm_smul, Real.norm_eq_abs, abs_of_pos hρ]
   field_simp [hρ.ne']
 
-/-- Lemma 3.5: on every stochastic admissible prefix, the squared KKT residual
-at iteration `k + 1` is bounded pathwise by the current and preceding squared
-step and gradient-error norms. -/
-theorem residual_sq_le
+/-- Pointwise form of Lemma 3.5: on every stochastic admissible prefix, the
+squared KKT residual at iteration `k + 1` is bounded by the current and
+preceding squared step and gradient-error norms. -/
+theorem residual_sq_le_of_isAdmissiblePrefix
     (run : StochasticRun h oracle ℙ x₀ multiplier₀ params Q B b)
     {N k : ℕ} (h_admissible : run.IsAdmissiblePrefix N)
     (hk_pos : 1 ≤ k) (hk : k < N) (ω : Ω) :
@@ -1450,6 +1450,30 @@ theorem residual_sq_le
         (‖run.step k ω‖ ^ 2 + ‖run.step (k - 1) ω‖ ^ 2 +
           ‖run.gradientError k ω‖ ^ 2 +
             ‖run.gradientError (k - 1) ω‖ ^ 2) := by ring
+
+/-- Lemma 3.5: on an almost-surely admissible stochastic prefix, the squared
+KKT residual at iteration `k + 1` obeys the stated pathwise bound almost
+surely. -/
+theorem residual_sq_le
+    (run : StochasticRun h oracle ℙ x₀ multiplier₀ params Q B b)
+    {N k : ℕ} (h_admissible : run.IsAEAdmissiblePrefix N)
+    (hk_pos : 1 ≤ k) (hk : k < N) :
+    ∀ᵐ ω ∂ℙ,
+      KKT.residual f c (run.point (k + 1) ω) (run.multiplier (k + 1) ω) ^ 2 ≤
+        stochasticResidualConstant h params.delta params.beta params.rho
+            params.multiplierBound *
+          (‖run.step k ω‖ ^ 2 + ‖run.step (k - 1) ω‖ ^ 2 +
+            ‖run.gradientError k ω‖ ^ 2 +
+              ‖run.gradientError (k - 1) ω‖ ^ 2) := by
+  obtain ⟨run', hrun'_admissible, hpoint, hmultiplier, hstep, herror⟩ :=
+    h_admissible.exists_pathwiseVersion run N
+  filter_upwards [hpoint (k + 1), hmultiplier (k + 1), hstep k,
+    hstep (k - 1), herror k, herror (k - 1)] with ω hpointSucc
+      hmultiplierSucc hstepCurrent hstepPrevious herrorCurrent herrorPrevious
+  have hbound := run'.residual_sq_le_of_isAdmissiblePrefix hrun'_admissible
+    hk_pos hk ω
+  simpa only [hpointSucc, hmultiplierSucc, hstepCurrent, hstepPrevious,
+    herrorCurrent, herrorPrevious] using hbound
 
 end LALM.StochasticRun
 

--- a/ReasBook/Papers/TR_LALM_theory/Theorem_3_6.lean
+++ b/ReasBook/Papers/TR_LALM_theory/Theorem_3_6.lean
@@ -260,7 +260,7 @@ private lemma fixedResidualMeanSquare_le
           (run.multiplier (k + 1) ω) ^ 2) ∂ℙ) ≤
         ∫⁻ ω, ENNReal.ofReal (C * moments ω) ∂ℙ := by
       refine lintegral_mono fun ω ↦ ENNReal.ofReal_le_ofReal ?_
-      exact run.residual_sq_le h_admissible hk_pos hk ω
+      exact run.residual_sq_le_of_isAdmissiblePrefix h_admissible hk_pos hk ω
     _ = ENNReal.ofReal (∫ ω, C * moments ω ∂ℙ) :=
       (ofReal_integral_eq_lintegral_ofReal hright hrightNonneg).symm
     _ = ENNReal.ofReal (C * ∫ ω, moments ω ∂ℙ) := by
@@ -320,9 +320,11 @@ theorem residualMeanSquare_le
     hasRegularOutputPoints_of_isAEAdmissiblePrefix run' K hrun'Admissible.isAE
   have hbatch := SPIDER.innerBatchSize_isSufficient h oracle params K
   have herrorAverage :=
-    run'.averageGradientErrorMeanSquare_le K hK hrun'Admissible hbatch
+    run'.averageGradientErrorMeanSquare_le_of_isAdmissiblePrefix K hK
+      hrun'Admissible hbatch
   have hstepAverage :=
-    run'.averageStepMeanSquare_le K hK hrun'Admissible hbatch
+    run'.averageStepMeanSquare_le_of_isAdmissiblePrefix K hK
+      hrun'Admissible hbatch
   rw [SPIDER.refreshBatchSize_coe K hK] at herrorAverage hstepAverage
   have hKreal : 0 < (K : ℝ) := by positivity
   have hKzero : (K : ℝ) ≠ 0 := hKreal.ne'


### PR DESCRIPTION
## Summary
- Add almost-sure admissibility wrappers for the stochastic moment and residual bounds in Lemmas 3.4 and 3.5.
- Preserve the pointwise helper theorems and update Theorem 3.6 to consume the faithful almost-sure interface.

## Validation
- `lake exe cache get`
- `lake build +TR_LALM_theory.Current` (3214 jobs)
- No `sorry`, `admit`, or project-defined axioms introduced.