### PR TITLE
fix(release): resume hidden GitHub drafts

### DIFF
--- a/sdk/deploy/src/reasbook_deploy_sdk/release/github.py
+++ b/sdk/deploy/src/reasbook_deploy_sdk/release/github.py
@@ -208,7 +208,7 @@ class GitHubReleasePublisher(GitHubRepositoryClient):
         self._require_publishable_tooling_revision(expected_registry_commit)
         self._require_immutable_releases_enabled()
 
-        existing_release = self._release_by_tag(tag)
+        existing_release = self._release_by_tag_including_drafts(tag)
         release_created = False
         workflow_ref: str | None = None
         if existing_release is None:
@@ -503,6 +503,89 @@ class GitHubReleasePublisher(GitHubRepositoryClient):
             raise DeployExecutionError("GitHub release JSON must be an object")
         return release
 
+    def _release_by_tag_including_drafts(self, tag: str) -> dict[str, Any] | None:
+        """Resolve an exact tag while accounting for REST hiding draft releases."""
+
+        release = self._release_by_tag(tag)
+        if release is not None:
+            return release
+
+        matches: list[dict[str, Any]] = []
+        for page in range(1, 101):
+            result = self._run(
+                "api",
+                f"repos/{self.profile.repository}/releases?per_page=100&page={page}",
+                "-H",
+                f"Accept: {GITHUB_JSON_ACCEPT}",
+                "-H",
+                f"X-GitHub-Api-Version: {GITHUB_API_VERSION}",
+                check=False,
+            )
+            if result.returncode != 0:
+                detail = (result.stderr or result.stdout).strip()
+                raise DeployExecutionError(
+                    "GitHub Release enumeration failed"
+                    + (f": {detail}" if detail else "")
+                )
+            try:
+                values = json.loads(result.stdout)
+            except json.JSONDecodeError as exc:
+                raise DeployExecutionError(
+                    "GitHub returned invalid release-list JSON"
+                ) from exc
+            if not isinstance(values, list) or not all(
+                isinstance(item, dict) for item in values
+            ):
+                raise DeployExecutionError("GitHub release-list JSON must be an array")
+            matches.extend(item for item in values if item.get("tag_name") == tag)
+            if len(matches) > 1:
+                raise DeployExecutionError(
+                    "GitHub returned multiple Releases for the requested tag"
+                )
+            if len(values) < 100:
+                return matches[0] if matches else None
+        raise DeployExecutionError(
+            "GitHub Release enumeration exceeded the bounded page limit"
+        )
+
+    def _release_by_id(self, release_id: int) -> dict[str, Any]:
+        """Return a known Release by database ID, including while it is a draft.
+
+        GitHub's tag lookup does not expose draft releases consistently.  Once
+        creation has returned a database ID, every pre-publication refresh must
+        therefore use the exact-ID endpoint rather than rediscovering the draft
+        through its tag.
+        """
+
+        if (
+            isinstance(release_id, bool)
+            or not isinstance(release_id, int)
+            or release_id < 1
+        ):
+            raise DeployExecutionError("GitHub Release has an invalid database ID")
+        result = self._run(
+            "api",
+            f"repos/{self.profile.repository}/releases/{release_id}",
+            "-H",
+            f"Accept: {GITHUB_JSON_ACCEPT}",
+            "-H",
+            f"X-GitHub-Api-Version: {GITHUB_API_VERSION}",
+            check=False,
+        )
+        if result.returncode != 0:
+            detail = (result.stderr or result.stdout).strip()
+            raise DeployExecutionError(
+                "GitHub Release disappeared before publication"
+                + (f": {detail}" if detail else "")
+            )
+        try:
+            release = json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            raise DeployExecutionError("GitHub returned invalid release JSON") from exc
+        if not isinstance(release, dict):
+            raise DeployExecutionError("GitHub release JSON must be an object")
+        return release
+
     def _create_draft_release(
         self,
         tag: str,
@@ -543,7 +626,7 @@ class GitHubReleasePublisher(GitHubRepositoryClient):
         )
         if result.returncode != 0:
             detail = (result.stderr or result.stdout).strip()
-            raced = self._release_by_tag(tag)
+            raced = self._release_by_tag_including_drafts(tag)
             if raced is None:
                 raise DeployExecutionError(
                     "cannot create draft GitHub Release"
@@ -606,11 +689,7 @@ class GitHubReleasePublisher(GitHubRepositoryClient):
             )
 
         for attempt in range(5):
-            release = self._release_by_tag(tag)
-            if release is None:
-                raise DeployExecutionError(
-                    "draft GitHub Release disappeared after asset upload"
-                )
+            release = self._release_by_id(expected_id)
             if (
                 release.get("draft") is not True
                 or release.get("tag_name") != tag
@@ -659,11 +738,7 @@ class GitHubReleasePublisher(GitHubRepositoryClient):
                 pending = exc
             if attempt < 4:
                 time.sleep(1.0)
-                refreshed = self._release_by_tag(tag)
-                if refreshed is None:
-                    raise DeployExecutionError(
-                        "draft GitHub Release disappeared during upload recovery"
-                    )
+                refreshed = self._release_by_id(expected_id)
                 release = refreshed
 
         assert pending is not None
@@ -676,11 +751,7 @@ class GitHubReleasePublisher(GitHubRepositoryClient):
             )
 
         for attempt in range(5):
-            refreshed = self._release_by_tag(tag)
-            if refreshed is None:
-                raise DeployExecutionError(
-                    "draft GitHub Release disappeared after upload cleanup"
-                )
+            refreshed = self._release_by_id(expected_id)
             self._require_draft_identity(refreshed, tag, expected_id)
             try:
                 return refreshed, self._validate_existing_release(

--- a/sdk/deploy/tests/test_release.py
+++ b/sdk/deploy/tests/test_release.py
@@ -2169,7 +2169,14 @@ class ReleasePlanningTests(unittest.TestCase):
 
     def test_github_publisher_uploads_then_dispatches_pages(self) -> None:
         class FakeRunner:
-            def __init__(self, paths=(), *, head: str | None = None, status: str = ""):
+            def __init__(
+                self,
+                paths=(),
+                *,
+                head: str | None = None,
+                status: str = "",
+                hidden_draft: bool = False,
+            ):
                 self.commands = []
                 self.paths = paths
                 self.head = head or "d" * 40
@@ -2178,6 +2185,7 @@ class ReleasePlanningTests(unittest.TestCase):
                 self.release_created = False
                 self.release_uploaded = False
                 self.release_published = False
+                self.hidden_draft = hidden_draft
 
             def run(self, command):
                 self.commands.append(command)
@@ -2212,6 +2220,12 @@ class ReleasePlanningTests(unittest.TestCase):
                         )
                     if "/releases/tags/" in endpoint:
                         if self.release_created:
+                            if self.hidden_draft and not self.release_published:
+                                return CommandResult(
+                                    command=command,
+                                    returncode=1,
+                                    stderr="gh: Not Found (HTTP 404)",
+                                )
                             return CommandResult(
                                 command=command,
                                 returncode=0,
@@ -2236,6 +2250,51 @@ class ReleasePlanningTests(unittest.TestCase):
                             command=command,
                             returncode=1,
                             stderr="gh: Not Found (HTTP 404)",
+                        )
+                    if "/releases?per_page=100&page=" in endpoint:
+                        releases = []
+                        if (
+                            self.release_created
+                            and self.hidden_draft
+                            and not self.release_published
+                        ):
+                            releases.append(
+                                {
+                                    "id": 123,
+                                    "tag_name": (
+                                        "reasbook-site-20260901T140000Z-"
+                                        "aaaaaaaaaaaa"
+                                    ),
+                                    "draft": True,
+                                    "immutable": False,
+                                    "assets": github_release_assets(self.paths),
+                                }
+                            )
+                        return CommandResult(
+                            command=command,
+                            returncode=0,
+                            stdout=json.dumps(releases),
+                        )
+                    if endpoint.endswith("/releases/123") and method == "GET":
+                        return CommandResult(
+                            command=command,
+                            returncode=0,
+                            stdout=json.dumps(
+                                {
+                                    "id": 123,
+                                    "tag_name": (
+                                        "reasbook-site-20260901T140000Z-"
+                                        "aaaaaaaaaaaa"
+                                    ),
+                                    "draft": not self.release_published,
+                                    "immutable": self.release_published,
+                                    "assets": (
+                                        github_release_assets(self.paths)
+                                        if self.release_uploaded
+                                        else []
+                                    ),
+                                }
+                            ),
                         )
                     if endpoint.endswith("/releases") and method == "POST":
                         self.release_created = True
@@ -2320,6 +2379,10 @@ class ReleasePlanningTests(unittest.TestCase):
                         "repos/acme/reasbook/releases/tags/"
                         "reasbook-site-20260901T140000Z-aaaaaaaaaaaa",
                     ),
+                    (
+                        "api",
+                        "repos/acme/reasbook/releases?per_page=100&page=1",
+                    ),
                     ("repo", "view"),
                     ("api", "repos/acme/reasbook/commits/main"),
                     ("rev-parse", "HEAD"),
@@ -2344,8 +2407,7 @@ class ReleasePlanningTests(unittest.TestCase):
                     ("release", "upload"),
                     (
                         "api",
-                        "repos/acme/reasbook/releases/tags/"
-                        "reasbook-site-20260901T140000Z-aaaaaaaaaaaa",
+                        "repos/acme/reasbook/releases/123",
                     ),
                     (
                         "api",
@@ -2535,6 +2597,10 @@ class ReleasePlanningTests(unittest.TestCase):
                         "repos/acme/reasbook/releases/tags/"
                         "reasbook-site-20260901T140000Z-aaaaaaaaaaaa",
                     ),
+                    (
+                        "api",
+                        "repos/acme/reasbook/releases?per_page=100&page=1",
+                    ),
                     ("repo", "view"),
                     ("api", "repos/acme/reasbook/commits/main"),
                     ("rev-parse", "HEAD"),
@@ -2561,6 +2627,42 @@ class ReleasePlanningTests(unittest.TestCase):
                     for command in audit_runner.commands
                 )
             )
+
+            resumed_runner = FakeRunner(assets, hidden_draft=True)
+            resumed_runner.tag_exists = True
+            resumed_runner.release_created = True
+            resumed_runner.release_uploaded = True
+            resumed = GitHubReleasePublisher(
+                GitHubPublishProfile(repository="acme/reasbook"),
+                runner=resumed_runner,
+                expected_registry_commit="d" * 40,
+                expected_tooling_revision=(
+                    "d" * 40 + "+tooling-sha256:" + "e" * 64
+                ),
+                expected_release_set_sha256=release_set_sha256,
+            ).publish(bundle)
+            resumed_verbs = [
+                command.argv[1:3] for command in resumed_runner.commands
+            ]
+            self.assertEqual(resumed.status, "dispatched")
+            self.assertNotIn(("release", "upload"), resumed_verbs)
+            self.assertFalse(
+                any(
+                    command.argv[1:4] == ("api", "--method", "POST")
+                    and command.argv[4] == "repos/acme/reasbook/releases"
+                    for command in resumed_runner.commands
+                )
+            )
+            resumed_publish = next(
+                command
+                for command in resumed_runner.commands
+                if command.argv[1:4] == ("api", "--method", "PATCH")
+            )
+            self.assertEqual(
+                resumed_publish.argv[4],
+                "repos/acme/reasbook/releases/123",
+            )
+            self.assertIn(("workflow", "run"), resumed_verbs)
 
             dirty_runner = FakeRunner(assets, status=" M local-change.py\n")
             with self.assertRaisesRegex(DeployExecutionError, "clean Git"):
@@ -2651,6 +2753,29 @@ class ReleasePlanningTests(unittest.TestCase):
                         command=command,
                         returncode=1,
                         stderr="gh: Not Found (HTTP 404)",
+                    )
+                if "/releases?per_page=100&page=" in endpoint:
+                    return CommandResult(command=command, returncode=0, stdout="[]")
+                if endpoint.endswith("/releases/123") and method == "GET":
+                    return CommandResult(
+                        command=command,
+                        returncode=0,
+                        stdout=json.dumps(
+                            {
+                                "id": 123,
+                                "tag_name": (
+                                    "reasbook-site-20260901T140000Z-"
+                                    "aaaaaaaaaaaa"
+                                ),
+                                "draft": not self.release_published,
+                                "immutable": self.release_published,
+                                "assets": (
+                                    github_release_assets(self.paths)
+                                    if self.release_uploaded
+                                    else []
+                                ),
+                            }
+                        ),
                     )
                 if endpoint.endswith("/releases") and method == "POST":
                     self.release_created = True
@@ -2895,6 +3020,27 @@ class ReleasePlanningTests(unittest.TestCase):
                                 }
                             ),
                         )
+                    if endpoint.endswith("/releases/123"):
+                        return CommandResult(
+                            command=command,
+                            returncode=0,
+                            stdout=json.dumps(
+                                {
+                                    "id": 123,
+                                    "tag_name": (
+                                        "reasbook-site-20260901T140000Z-"
+                                        "aaaaaaaaaaaa"
+                                    ),
+                                    "draft": True,
+                                    "immutable": False,
+                                    "assets": (
+                                        github_release_assets(self.paths)
+                                        if self.release_uploaded
+                                        else []
+                                    ),
+                                }
+                            ),
+                        )
                     if "/git/ref/tags/" in endpoint:
                         self.tag_reads += 1
                         target = "c" * 40 if self.tag_reads == 1 else "d" * 40
@@ -2945,7 +3091,49 @@ class ReleasePlanningTests(unittest.TestCase):
             runner=FailedLookupRunner(),
         )
         with self.assertRaisesRegex(DeployExecutionError, "release lookup failed.*403"):
-            publisher._release_by_tag("reasbook-site-safe")
+            publisher._release_by_tag_including_drafts("reasbook-site-safe")
+
+    def test_github_release_lookup_recovers_exact_draft_hidden_by_tag_api(
+        self,
+    ) -> None:
+        tag = "reasbook-site-20260901T140000Z-aaaaaaaaaaaa"
+        draft = {
+            "id": 383249278,
+            "tag_name": tag,
+            "draft": True,
+            "immutable": False,
+            "assets": [],
+        }
+
+        class HiddenDraftRunner:
+            def __init__(self):
+                self.commands = []
+
+            def run(self, command):
+                self.commands.append(command)
+                endpoint = command.argv[2]
+                if "/releases/tags/" in endpoint:
+                    return CommandResult(
+                        command=command,
+                        returncode=1,
+                        stderr="gh: Not Found (HTTP 404)",
+                    )
+                if "/releases?per_page=100&page=1" in endpoint:
+                    return CommandResult(
+                        command=command,
+                        returncode=0,
+                        stdout=json.dumps([draft]),
+                    )
+                raise AssertionError(command.argv)
+
+        runner = HiddenDraftRunner()
+        publisher = GitHubReleasePublisher(
+            GitHubPublishProfile(repository="acme/reasbook"),
+            runner=runner,
+        )
+
+        self.assertEqual(publisher._release_by_tag_including_drafts(tag), draft)
+        self.assertEqual(len(runner.commands), 2)
 
     def test_github_rest_release_creation_adopts_only_an_observed_race(self) -> None:
         tag = "reasbook-site-20260901T140000Z-aaaaaaaaaaaa"
@@ -2982,6 +3170,23 @@ class ReleasePlanningTests(unittest.TestCase):
                                 "assets": [],
                             }
                         ),
+                    )
+                if "/releases?per_page=100&page=" in command.argv[2]:
+                    values = []
+                    if self.observed:
+                        values.append(
+                            {
+                                "id": 456,
+                                "tag_name": tag,
+                                "draft": True,
+                                "immutable": False,
+                                "assets": [],
+                            }
+                        )
+                    return CommandResult(
+                        command=command,
+                        returncode=0,
+                        stdout=json.dumps(values),
                     )
                 raise AssertionError(command.argv)
 
@@ -3062,6 +3267,65 @@ class ReleasePlanningTests(unittest.TestCase):
             self.assertEqual(verified, complete)
             self.assertEqual(runner.calls, 2)
             sleep.assert_called_once_with(1.0)
+
+    def test_github_draft_asset_verification_uses_known_release_id(self) -> None:
+        tag = "reasbook-site-20260901T140000Z-aaaaaaaaaaaa"
+
+        class DraftLookupRunner:
+            def __init__(self, release):
+                self.release = release
+                self.commands = []
+
+            def run(self, command):
+                self.commands.append(command)
+                endpoint = next(
+                    part for part in command.argv if part.startswith("repos/")
+                )
+                if "/releases/tags/" in endpoint:
+                    return CommandResult(
+                        command=command,
+                        returncode=1,
+                        stderr="gh: Not Found (HTTP 404)",
+                    )
+                if endpoint.endswith("/releases/383249278"):
+                    return CommandResult(
+                        command=command,
+                        returncode=0,
+                        stdout=json.dumps(self.release),
+                    )
+                raise AssertionError(command.argv)
+
+        with tempfile.TemporaryDirectory() as temp:
+            release_id = "site-20260901T140000Z-" + "a" * 12
+            _, paths = github_pages_bundle_fixture(Path(temp), release_id)
+            draft = {
+                "id": 383249278,
+                "tag_name": tag,
+                "draft": True,
+                "immutable": False,
+                "assets": github_release_assets(paths),
+            }
+            runner = DraftLookupRunner(draft)
+            publisher = GitHubReleasePublisher(
+                GitHubPublishProfile(repository="acme/reasbook"),
+                runner=runner,
+            )
+
+            verified = publisher._wait_for_complete_draft_assets(
+                tag,
+                draft,
+                tuple(paths),
+                publisher._snapshot_assets(tuple(paths)),
+            )
+
+            self.assertEqual(verified, draft)
+            self.assertEqual(len(runner.commands), 1)
+            self.assertTrue(
+                any(
+                    part.endswith("/releases/383249278")
+                    for part in runner.commands[0].argv
+                )
+            )
 
     def test_github_draft_asset_verification_fails_closed(self) -> None:
         tag = "reasbook-site-20260901T140000Z-aaaaaaaaaaaa"
@@ -3172,7 +3436,7 @@ class ReleasePlanningTests(unittest.TestCase):
                     if method == "DELETE":
                         self.release = {**self.release, "assets": []}
                         return CommandResult(command=command, returncode=0)
-                if "/releases/tags/" in endpoint:
+                if endpoint.endswith("/releases/123"):
                     return CommandResult(
                         command=command,
                         returncode=0,


### PR DESCRIPTION
GitHub does not consistently expose draft Releases through the release-by-tag endpoint. This makes a successful asset upload look like the draft disappeared and prevents the one-click publisher from resuming.

This change falls back to authenticated, bounded release enumeration only after an explicit tag lookup 404. Once a draft database ID is known, all pre-publication refreshes use that exact ID. Existing tag, draft, ID, digest, immutable-release, and registry-commit gates remain fail-closed.

Regression coverage includes the complete interrupted-publish path: recover a hidden draft, verify all existing assets, skip create/upload, publish the same database ID, and dispatch Pages.

Validation:
- capability SDK suite: 123 passed
- repository suite on Python 3.11: 43 passed
- Ruff: passed
- git diff check: passed