### PR TITLE
fix(verso): escape supporting module labels

### DIFF
--- a/ReasBookWeb/scripts/gen_sections.py
+++ b/ReasBookWeb/scripts/gen_sections.py
@@ -2476,7 +2476,7 @@ def write_work_pages(
             for source in reader.support_modules:
                 docs_path = _module_to_docs_path(source_root, source.module)
                 lines.append(
-                    f"- {source.relative_path} "
+                    f"- `{source.relative_path}` "
                     f"([API documentation]({portable_site_link(f'docs/ReasBook/{docs_path}.html')})) "
                     f"([Lean source]({github_blob_link(source.source_path)}))"
                 )

--- a/tests/test_repository_scripts.py
+++ b/tests/test_repository_scripts.py
@@ -684,6 +684,8 @@ class RepositoryScriptTests(unittest.TestCase):
                     "REASBOOK_INCLUDE_PROJECTS": "books/BauschkeLike",
                     "REASBOOK_EXCLUDE_PROJECTS": "",
                     "REASBOOK_PROJECT_FRAGMENT": "0",
+                    "REASBOOK_GITHUB_REPO": "example/reasbook-test",
+                    "REASBOOK_GITHUB_BRANCH": "test-branch",
                 },
                 capture_output=True,
                 text=True,
@@ -718,9 +720,20 @@ class RepositoryScriptTests(unittest.TestCase):
             self.assertIn("# Chapter items", reader)
             self.assertIn("# Section 1.2", reader)
             self.assertIn("Definition 1.2.extra.1", reader)
-            self.assertIn("Helper_1_1.lean", reader)
-            self.assertIn("Lemma_9_1.lean", reader)
-            self.assertIn("Definition_1_1/Implementation.lean", reader)
+            self.assertIn("`Helper_1_1.lean`", reader)
+            self.assertIn("`Lemma_9_1.lean`", reader)
+            self.assertIn("`Definition_1_1/Implementation.lean`", reader)
+            self.assertIn(
+                "https://github.com/example/reasbook-test/blob/test-branch/"
+                "ReasBook/Books/BauschkeLike/Chap01/Helper_1_1.lean",
+                reader,
+            )
+            self.assertIn(
+                "https://github.com/example/reasbook-test/blob/test-branch/"
+                "ReasBook/Books/BauschkeLike/Chap01/Definition_1_1/"
+                "Implementation.lean",
+                reader,
+            )
             self.assertNotIn("## ", reader)
             self.assertFalse(
                 (


### PR DESCRIPTION
Fix project Verso generation when a supporting Lean filename contains underscores. The visible label is emitted as a Markdown code span while API and source URLs remain unchanged. Regression tests cover flat and nested supporting-module paths. Local verification: repository script tests 29/29 and full sdk/test.sh passed.