### PR TITLE
fix(pages): share Verso assets and select canonical releases

### DIFF
--- a/config/deploy/github-pages.yml
+++ b/config/deploy/github-pages.yml
@@ -5,7 +5,9 @@ registry: config/toolchains.yml
 canonical_projects: config/canonical-projects.yml
 
 selection:
-  mode: all_active
+  # Publish one explicitly selected version per project. Existing immutable
+  # release archives retain previous versions; URLs remain version-qualified.
+  mode: canonical
   exclude:
     - books/ProbabilityTheory_Klenke_2020
     - books/ComputationalMethodsInverseProblems_Vogel_2002
@@ -25,7 +27,7 @@ policy:
 
 # A release has one build identity and two immutable delivery artifacts.
 # The full artifact retains bounded reachable project-module API docs and every
-# project version for self-hosting. Pages keeps canonical Verso routes and all
+# selected project version for self-hosting. Pages keeps canonical Verso routes and all
 # API pages owned by every selected ProjectSpec; omitted external-dependency
 # API links become explicit placeholders whose source pages must exist in the
 # verified full artifact.

--- a/docs/decisions/0019-canonical-release-selection-and-shared-verso-assets.md
+++ b/docs/decisions/0019-canonical-release-selection-and-shared-verso-assets.md
@@ -29,6 +29,9 @@ a new release is not a useful substitute for the archived original release.
   project, retaining a matching deep suffix where possible. The redirect clearly
   states that it targets the canonical version. Never replace an API page with a
   capacity placeholder simply because it is large.
+- Keep existing API namespaces of known selected projects across retained
+  branches when doc-gen's navbar/search data refers to them. Canonical reader
+  selection must not turn those real API links into 404s or placeholders.
 - During Pages projection, share repeated attribute-free classic scripts and
   styles from Verso heads using content-addressed `static/shared-verso/` assets.
   Scripts remain parser-blocking and in their original order. Native Lean HTML,
@@ -42,6 +45,10 @@ a new release is not a useful substitute for the archived original release.
 - A chapter index with Docs links is labelled and reported as an index, not as
   newly compiled item-level Verso. Cached compilation status alone is not proof
   of reading content; check visible pages and real navigation before promotion.
+- When an indexed item lacks an API page, replace only its generated API link
+  with an explicit unavailable label if the adjacent same-module Lean source
+  was verified in the pinned Git tree. Keep a commit-qualified source link.
+  Never generate a fake API page or suppress unrelated link errors.
 - Keep all existing checksum, immutable release, content, browser and capacity
   gates. Selection is explicit in configuration, never an automatic response to
   exceeding the budget.

--- a/docs/decisions/0019-canonical-release-selection-and-shared-verso-assets.md
+++ b/docs/decisions/0019-canonical-release-selection-and-shared-verso-assets.md
@@ -4,6 +4,10 @@
 
 Accepted
 
+## Date
+
+2026-09-07
+
 ## Context
 
 The May/Forster Pages refresh exceeded the 920 MB operational budget before

--- a/docs/decisions/0019-canonical-release-selection-and-shared-verso-assets.md
+++ b/docs/decisions/0019-canonical-release-selection-and-shared-verso-assets.md
@@ -1,0 +1,60 @@
+# ADR-0019: Canonical release selection and shared Verso assets
+
+## Status
+
+Accepted
+
+## Context
+
+The May/Forster Pages refresh exceeded the 920 MB operational budget before
+publication. The old Pages artifact alone occupied 885,479,760 bytes. An audit
+found approximately 74 MB of duplicate plain inline scripts and 12 MB of
+duplicate styles in Verso heads. Much of that data is an identical navigation
+catalog repeated in hundreds of pages, not mathematical content.
+
+Several old versioned paper readers also contain empty sections. Newer canonical
+readers are available in verified caches; retaining an empty historic reader in
+a new release is not a useful substitute for the archived original release.
+
+## Decision
+
+- Add explicit `selection.mode: canonical` alongside the backward-compatible
+  `all_active` mode. It selects one configured canonical occurrence per project.
+  This is independent of `site.include_historical_versions`, which remains true
+  in the Pages profile to preserve `/versions/<version>/` URL prefixes.
+- Both delivery artifacts describe the same selected ProjectSpecs. `full` keeps
+  the full content of that selection; previous immutable releases and caches
+  remain available. This does not relabel newer Lean artifacts as old versions.
+- Existing historical reading links may redirect to the explicitly canonical
+  project, retaining a matching deep suffix where possible. The redirect clearly
+  states that it targets the canonical version. Never replace an API page with a
+  capacity placeholder simply because it is large.
+- During Pages projection, share repeated attribute-free classic scripts and
+  styles from Verso heads using content-addressed `static/shared-verso/` assets.
+  Scripts remain parser-blocking and in their original order. Native Lean HTML,
+  prose and anchors in the body are byte-identical; Docs HTML is not rewritten.
+- Leave context-sensitive assets inline: CSS relative resources/imports, module
+  imports, `document.currentScript`, source maps, CSP pages, templates and
+  conditional/noscript content. No global minification or code truncation.
+- Reuse separately verified Verso producer caches without replacing existing
+  Docs, Source or Graph output. Numeric tooltip databases are namespaced per
+  producer. Preserve route aliases emitted by the maintained Pages assembler.
+- A chapter index with Docs links is labelled and reported as an index, not as
+  newly compiled item-level Verso. Cached compilation status alone is not proof
+  of reading content; check visible pages and real navigation before promotion.
+- Keep all existing checksum, immutable release, content, browser and capacity
+  gates. Selection is explicit in configuration, never an automatic response to
+  exceeding the budget.
+
+This refines ADR-0008's selection scope, not its guarantee to retain API pages
+owned by every selected ProjectSpec. ADR-0002 still governs artifact binding and
+immutable publication. The independently deployed Reviewer and its review data
+are unaffected by this static Pages operation.
+
+## Alternatives considered
+
+Deleting proof bodies or selected API documentation was rejected because it
+breaks the reader. Raising the budget was rejected because GitHub's 1 GB hard
+limit remains. Keeping every historical occurrence remains available through
+`all_active`, but is not the default for this public refresh. Removing remote
+caches is unnecessary and would discard reusable compilation work.

--- a/scripts/pages/assemble.py
+++ b/scripts/pages/assemble.py
@@ -42,6 +42,12 @@ _HREF_RE = re.compile(
     r"\bhref\s*=\s*(?P<quote>['\"])(?P<href>.*?)(?P=quote)",
     flags=re.IGNORECASE,
 )
+_SOURCE_DOCUMENTATION_PAIR_RE = re.compile(
+    r"(?P<documentation><a\b[^>]*>\s*API documentation\s*</a>)"
+    r"(?P<separator>\s*\)\s*\(\s*)"
+    r"(?P<source><a\b[^>]*>\s*Lean source\s*</a>)",
+    flags=re.IGNORECASE,
+)
 _UNAVAILABLE_DOCUMENTATION_MANIFEST = "unavailable-documentation.json"
 
 
@@ -274,7 +280,9 @@ def _internal_link_target(
     return candidate
 
 
-def reconcile_documentation_links(site_root: Path) -> dict[str, object]:
+def reconcile_documentation_links(
+    site_root: Path, *, verified_source_links: dict[str, str] | None = None,
+) -> dict[str, object]:
     """Make unavailable API links explicit while preserving strict closure.
 
     Verso intentionally renders source modules beyond a project's public
@@ -284,17 +292,24 @@ def reconcile_documentation_links(site_root: Path) -> dict[str, object]:
     pair is downgraded only when its API target is absent *and* its adjacent
     Verso target exists.  Every other missing link remains untouched so the
     subsequent strict verifier still fails closed.
+
+    An operator may additionally supply source URLs verified against pinned Git
+    objects, mapped to their immutable commit URLs. Only adjacent generated
+    API/Lean-source pairs with matching module names use that fallback. No API
+    placeholder page is fabricated, and ordinary broken links are not waived.
     """
 
     base_path = _site_base_path()
     occurrences: dict[tuple[str, str], list[str]] = defaultdict(list)
     replacement_count = 0
+    source_occurrences: dict[tuple[str, str], list[str]] = defaultdict(list)
 
     for document in sorted(site_root.rglob("*.html")):
         if document.is_symlink() or not document.is_file():
             continue
         source = document.read_text(encoding="utf-8", errors="replace")
-        if "Documentation" not in source or "Verso" not in source:
+        if not (("Documentation" in source and "Verso" in source) or
+                (verified_source_links and "API documentation" in source)):
             continue
 
         relative_document = document.relative_to(site_root).as_posix()
@@ -339,6 +354,29 @@ def reconcile_documentation_links(site_root: Path) -> dict[str, object]:
             )
 
         rendered = _DOCUMENTATION_PAIR_RE.sub(replace, source)
+        def replace_source(match: re.Match[str]) -> str:
+            nonlocal replacement_count
+            if "docs" in document.relative_to(site_root).parts:
+                return match.group(0)
+            docs_href = _anchor_href(match.group("documentation"))
+            source_href = _anchor_href(match.group("source"))
+            pinned = (verified_source_links or {}).get(source_href or "")
+            if not docs_href or not pinned or not re.fullmatch(
+                r"https://github[.]com/[^/]+/[^/]+/blob/[0-9a-f]{40}/[^?#]+[.]lean", pinned
+            ):
+                return match.group(0)
+            target = _internal_link_target(site_root, document, docs_href, base_path=base_path)
+            if target is None or target.is_file() or target.stem != Path(urlsplit(pinned).path).stem:
+                return match.group(0)
+            replacement_count += 1
+            source_occurrences[(docs_href, pinned)].append(relative_document)
+            return ('<span class="documentation-unavailable" title="API documentation '
+                    'has not been generated for this item">API documentation unavailable</span>'
+                    + match.group("separator")
+                    + f'<a href="{html.escape(pinned, quote=True)}">Lean source</a>')
+
+        if verified_source_links:
+            rendered = _SOURCE_DOCUMENTATION_PAIR_RE.sub(replace_source, rendered)
         if rendered != source:
             temporary = document.with_name(f".{document.name}.tmp")
             temporary.write_text(rendered, encoding="utf-8")
@@ -360,6 +398,11 @@ def reconcile_documentation_links(site_root: Path) -> dict[str, object]:
         "replacement_count": replacement_count,
         "schema_version": 1,
     }
+    if verified_source_links:
+        manifest["policy"] = "missing-api-page-with-verified-reading-or-source-fallback"
+        entries.extend({"documentation_href": docs, "source_href": pinned,
+                        "source_pages": sorted(pages), "fallback_kind": "pinned-git-source"}
+                       for (docs, pinned), pages in sorted(source_occurrences.items()))
     (site_root / _UNAVAILABLE_DOCUMENTATION_MANIFEST).write_text(
         json.dumps(manifest, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",

--- a/sdk/deploy/README.md
+++ b/sdk/deploy/README.md
@@ -283,6 +283,15 @@ enforced even if the operational policy is later raised. A bundle that the
 workflow would reject cannot pass local packaging merely because a verifier
 default was looser.
 
+The public profile uses `selection.mode: canonical`: one configured canonical
+version per book or paper, while retaining version-qualified URLs. Use
+`all_active` explicitly when preparing a release containing every active
+occurrence. Existing immutable releases and compilation caches are not deleted.
+Pages shares safe, repeated Verso head scripts/styles through content-hashed
+assets; native Lean/prose body bytes and selected project Docs are preserved.
+See [ADR-0019](../../../docs/decisions/0019-canonical-release-selection-and-shared-verso-assets.md)
+for selection, historical-link and cache-reuse boundaries.
+
 When `--wait` is present, the command first waits up to 1,800 seconds for the
 workflow and then up to 300 seconds for the public Pages ReleaseSpec to
 converge. It verifies the exact release ID, ReleaseSpec digest, and registry

--- a/sdk/deploy/README.md
+++ b/sdk/deploy/README.md
@@ -289,7 +289,7 @@ version per book or paper, while retaining version-qualified URLs. Use
 occurrence. Existing immutable releases and compilation caches are not deleted.
 Pages shares safe, repeated Verso head scripts/styles through content-hashed
 assets; native Lean/prose body bytes and selected project Docs are preserved.
-See [ADR-0019](../../../docs/decisions/0019-canonical-release-selection-and-shared-verso-assets.md)
+See [ADR-0019](../../docs/decisions/0019-canonical-release-selection-and-shared-verso-assets.md)
 for selection, historical-link and cache-reuse boundaries.
 
 When `--wait` is present, the command first waits up to 1,800 seconds for the

--- a/sdk/deploy/src/reasbook_deploy_sdk/release/artifacts.py
+++ b/sdk/deploy/src/reasbook_deploy_sdk/release/artifacts.py
@@ -30,6 +30,7 @@ from .results import (
     ReleaseSetManifest,
 )
 from .store import ReleaseLayout, ReleaseStore
+from .static_assets import deduplicate_verso_assets
 
 
 _SHARED_DOC_DIRECTORIES = {"declarations", "find", "src"}
@@ -165,6 +166,7 @@ class PagesSiteProjector:
                 Path("versions") / "index.html",
             )
             self._write_catalog_redirects(spec, staged, canonical_routes)
+            deduplicate_verso_assets(staged, spec.base_path)
             self._close_internal_references(
                 spec,
                 full_site,
@@ -773,7 +775,11 @@ class PagesSiteProjector:
         branch = parts[1]
         route = Path(*parts[2:])
         for project in spec.projects:
-            if project.branch != branch or project.canonical:
+            # Canonical-only releases deliberately omit old ProjectSpecs, but
+            # old, verified API pages can still link to their Verso URLs.
+            if project.canonical and project.branch == branch:
+                continue
+            if not project.canonical and project.branch != branch:
                 continue
             for root in (Path(project.kind) / project.slug, Path(project.slug)):
                 if route == root or root in route.parents:

--- a/sdk/deploy/src/reasbook_deploy_sdk/release/artifacts.py
+++ b/sdk/deploy/src/reasbook_deploy_sdk/release/artifacts.py
@@ -264,7 +264,11 @@ class PagesSiteProjector:
         # the projects selected as catalog canonicals. Copy all known project
         # namespaces before link closure so cross-project API links remain real.
         project_docs: dict[str, Path] = {}
-        for project in branch_projects:
+        # A retained doc-gen navbar/search database can name an older namespace
+        # of a selected project. Keep its real API pages even when that reading
+        # occurrence is no longer selected; never replace them with fake stubs.
+        documentation_owners = {project.key: project for project in spec.projects}
+        for project in documentation_owners.values():
             if "docs" not in project.outputs:
                 continue
             docs = self._copy_project_docs(
@@ -275,6 +279,8 @@ class PagesSiteProjector:
                 project.build_target,
             )
             if docs is None:
+                if project.key not in {item.key for item in branch_projects}:
+                    continue
                 raise DeployExecutionError(
                     "Pages projection has no project-owned API entry: "
                     f"{project.key}@{branch}"

--- a/sdk/deploy/src/reasbook_deploy_sdk/release/artifacts.py
+++ b/sdk/deploy/src/reasbook_deploy_sdk/release/artifacts.py
@@ -166,6 +166,7 @@ class PagesSiteProjector:
                 Path("versions") / "index.html",
             )
             self._write_catalog_redirects(spec, staged, canonical_routes)
+            self._write_historical_reading_redirects(spec, full_site, staged, canonical_routes)
             deduplicate_verso_assets(staged, spec.base_path)
             self._close_internal_references(
                 spec,
@@ -496,6 +497,28 @@ class PagesSiteProjector:
                 f"Pages projection is {total_bytes} bytes; budget is "
                 f"{self.max_site_bytes}"
             )
+
+    def _write_historical_reading_redirects(
+        self, spec: ReleaseSpec, source: Path, target: Path,
+        routes: dict[str, tuple[Path | None, Path | None]],
+    ) -> None:
+        # Sidebar URLs live in JavaScript, so ordinary HTML link closure does
+        # not discover every historical route. Keep all known reading indexes
+        # as tiny explicit redirects, never copy their old proof bodies.
+        for branch in spec.branches:
+            for project in spec.canonical_projects():
+                if project.branch == branch.name:
+                    continue
+                for root in (Path(project.kind) / project.slug, Path(project.slug)):
+                    relative = Path("versions") / branch.name / root
+                    for index in (source / relative).rglob("index.html"):
+                        route = index.relative_to(source)
+                        destination = target / route
+                        if destination.exists():
+                            continue
+                        canonical = self._canonical_history_target(spec, route, target, routes)
+                        if canonical is not None:
+                            self._write_history_redirect(destination, canonical, spec.base_path)
 
     def _write_catalog_redirects(
         self,

--- a/sdk/deploy/src/reasbook_deploy_sdk/release/config.py
+++ b/sdk/deploy/src/reasbook_deploy_sdk/release/config.py
@@ -117,8 +117,9 @@ def load_profile(path: str | Path, *, repo_root: str | Path) -> DeploymentProfil
     else:
         selection = _mapping(selection_value, field="selection")
     _expect_keys(selection, {"mode", "exclude"}, field="selection")
-    if selection.get("mode", "all_active") != "all_active":
-        raise DeployConfigError("selection.mode currently supports only all_active")
+    selection_mode = selection.get("mode", "all_active")
+    if selection_mode not in {"all_active", "canonical"}:
+        raise DeployConfigError("selection.mode must be all_active or canonical")
     raw_exclude = selection.get("exclude", [])
     if not isinstance(raw_exclude, list) or not all(
         isinstance(item, str) for item in raw_exclude
@@ -265,6 +266,7 @@ def load_profile(path: str | Path, *, repo_root: str | Path) -> DeploymentProfil
             workflow=str(publish_value.get("workflow", "publish_release_pages.yml")),
         ),
         exclude=tuple(sorted(set(raw_exclude))),
+        selection_mode=selection_mode,
         artifacts=artifacts,
     )
 
@@ -325,7 +327,7 @@ def dump_profile_snapshot(profile: DeploymentProfile) -> str:
         "registry": "toolchains.yml",
         "canonical_projects": "canonical-projects.yml",
         "selection": {
-            "mode": "all_active",
+            "mode": profile.selection_mode,
             "exclude": list(profile.exclude),
         },
         "site": {

--- a/sdk/deploy/src/reasbook_deploy_sdk/release/models.py
+++ b/sdk/deploy/src/reasbook_deploy_sdk/release/models.py
@@ -239,9 +239,12 @@ class DeploymentProfile:
     artifacts: tuple[ReleaseArtifactPolicy, ...] = field(
         default_factory=default_artifact_policies
     )
+    selection_mode: str = "all_active"
 
     def __post_init__(self) -> None:
         _text(self.name, field="profile.name")
+        if self.selection_mode not in {"all_active", "canonical"}:
+            raise DeployConfigError("selection.mode must be all_active or canonical")
         if not isinstance(self.include_historical_versions, bool):
             raise DeployConfigError("site.include_historical_versions must be boolean")
         object.__setattr__(self, "base_path", _base_path(self.base_path))

--- a/sdk/deploy/src/reasbook_deploy_sdk/release/planner.py
+++ b/sdk/deploy/src/reasbook_deploy_sdk/release/planner.py
@@ -86,7 +86,7 @@ class ReleasePlanner:
             canonical_branch = self._canonical_branch(key, versions, canonical)
             for branch, project in versions:
                 is_canonical = branch.spec.name == canonical_branch
-                if not profile.include_historical_versions and not is_canonical:
+                if (not profile.include_historical_versions or profile.selection_mode == "canonical") and not is_canonical:
                     continue
                 try:
                     target = target_from_declarations(

--- a/sdk/deploy/src/reasbook_deploy_sdk/release/static_assets.py
+++ b/sdk/deploy/src/reasbook_deploy_sdk/release/static_assets.py
@@ -1,0 +1,136 @@
+"""Share repeated Verso head assets without rewriting mathematical content."""
+from __future__ import annotations
+
+from collections import Counter
+import hashlib
+from html.parser import HTMLParser
+from pathlib import Path
+import re
+
+from reasbook_sdk_common import atomic_write_text
+
+_LIMIT = 1024 * 1024
+_CONTEXT_SENSITIVE = re.compile(
+    r"document\s*\.\s*currentScript|\bimport\s*\(|\bimport\s*\.\s*meta|"
+    r"sourceMappingURL|\burl\s*\(|@import", re.I
+)
+
+
+class _Head(HTMLParser):
+    def __init__(self, text: str):
+        super().__init__(convert_charrefs=False)
+        self.text = text
+        self.lines = [0]
+        for match in re.finditer("\n", text):
+            self.lines.append(match.end())
+        self.in_head = False
+        self.closed = False
+        self.csp = False
+        self.hidden = 0
+        self.active: tuple[str, int, int] | None = None
+        self.blocks: list[tuple[int, int, str, str]] = []
+
+    def absolute_position(self) -> int:
+        line, column = self.getpos()
+        return self.lines[line - 1] + column
+
+    def handle_starttag(self, tag, attrs):
+        if tag == "head":
+            self.in_head = True
+        if tag in {"template", "noscript"}:
+            self.hidden += 1
+        values = dict(attrs)
+        if tag == "meta" and (values.get("http-equiv") or "").lower() == "content-security-policy":
+            self.csp = True
+        if self.in_head and not self.hidden and tag in {"style", "script"} and not attrs:
+            start = self.absolute_position()
+            self.active = tag, start, start + len(self.get_starttag_text())
+
+    def handle_endtag(self, tag):
+        if self.active and self.active[0] == tag:
+            _, start, content_start = self.active
+            end = self.absolute_position()
+            content = self.text[content_start:end]
+            if len(content) >= 256 and not _CONTEXT_SENSITIVE.search(content):
+                self.blocks.append((start, self.text.index(">", end) + 1, tag, content))
+            self.active = None
+        if tag in {"template", "noscript"}:
+            self.hidden = max(0, self.hidden - 1)
+        if tag == "head":
+            self.in_head = False
+            self.closed = True
+
+
+def _head(path: Path) -> _Head | None:
+    # Only head assets are candidates. Do not parse huge Lean expression bodies.
+    with path.open("rb") as stream:
+        prefix = stream.read(_LIMIT)
+    end = re.search(rb"</head\s*>", prefix, re.I)
+    if end is None or b"__versoSiteRoot" not in prefix[:end.end()]:
+        return None
+    try:
+        text = prefix[:end.end()].decode("utf-8")
+    except UnicodeDecodeError:
+        return None
+    parser = _Head(text)
+    parser.feed(text)
+    return parser if parser.closed and not parser.csp else None
+
+
+def deduplicate_verso_assets(site: Path, base_path: str) -> dict[str, int]:
+    """Modify a private staging tree only; preserve Docs and all body bytes.
+
+    Only repeated attribute-free classic scripts/styles are extracted. Scripts
+    remain parser-blocking at their original positions. Relative CSS resources,
+    module imports, currentScript, CSP, templates and conditional blocks are
+    excluded because moving them could change behavior.
+    """
+    root = Path(site)
+    counts: Counter[tuple[str, str]] = Counter()
+    documents = []
+    for path in sorted(root.rglob("*.html")):
+        if "docs" in path.relative_to(root).parts:
+            continue
+        if path.is_symlink():
+            raise ValueError(f"symlinked Verso page: {path}")
+        head = _head(path)
+        if head is None:
+            continue
+        documents.append(path)
+        for _, _, tag, content in head.blocks:
+            counts[tag, hashlib.sha256(content.encode()).hexdigest()] += 1
+    saved = assets = replaced = 0
+    written = set()
+    for path in documents:
+        head = _head(path)
+        assert head is not None
+        text = head.text
+        for start, end, tag, content in reversed(head.blocks):
+            digest = hashlib.sha256(content.encode()).hexdigest()
+            key = tag, digest
+            if counts[key] < 2:
+                continue
+            suffix = "js" if tag == "script" else "css"
+            relative = Path("static/shared-verso") / f"{digest}.{suffix}"
+            target = root / relative
+            if key not in written:
+                if target.exists() and (target.is_symlink() or target.read_text() != content):
+                    raise ValueError("shared Verso asset collision")
+                atomic_write_text(target, content)
+                written.add(key)
+                assets += 1
+                saved -= len(content.encode())
+            url = base_path + relative.as_posix()
+            replacement = (f'<script src="{url}"></script>' if tag == "script"
+                           else f'<link rel="stylesheet" href="{url}">')
+            saved += len(text[start:end].encode()) - len(replacement.encode())
+            text = text[:start] + replacement + text[end:]
+            replaced += 1
+        if text != head.text:
+            original = path.read_bytes()
+            head_bytes = head.text.encode()
+            if not original.startswith(head_bytes):
+                raise ValueError("Verso staging tree changed during deduplication")
+            # Native highlighted Lean, prose, anchors and body scripts are untouched.
+            path.write_bytes(text.encode() + original[len(head_bytes):])
+    return {"assets": assets, "replaced_blocks": replaced, "saved_bytes": saved}

--- a/sdk/deploy/tests/test_release.py
+++ b/sdk/deploy/tests/test_release.py
@@ -1396,6 +1396,9 @@ class ReleasePlanningTests(unittest.TestCase):
                 '{"internal":true}\n',
                 encoding="utf-8",
             )
+            sidebar_only = layout.site / "versions/v4.26.0/books/demo/sidebar-only/index.html"
+            sidebar_only.parent.mkdir(parents=True)
+            sidebar_only.write_text("<html><body>Old body not retained</body></html>")
             full_site_identity = site_tree_digest(layout.site)
 
             broken_full = root / "broken-full"
@@ -1487,6 +1490,9 @@ class ReleasePlanningTests(unittest.TestCase):
                 history_redirect,
             )
             self.assertNotIn('data-reasbook-doc-stub="true"', history_redirect)
+            sidebar_redirect = (layout.pages_site / sidebar_only.relative_to(layout.site)).read_text()
+            self.assertIn('data-reasbook-history-redirect="true"', sidebar_redirect)
+            self.assertNotIn("Old body not retained", sidebar_redirect)
             self.assertFalse((layout.pages_site / "books").exists())
             self.assertFalse((layout.pages_site / "papers").exists())
             self.assertFalse(

--- a/sdk/deploy/tests/test_release.py
+++ b/sdk/deploy/tests/test_release.py
@@ -924,6 +924,20 @@ class ReleasePlanningTests(unittest.TestCase):
                 ],
             )
 
+    def test_canonical_selection_retains_version_qualified_routes(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            configured = replace(profile(Path(temp)), selection_mode="canonical")
+            spec = ReleasePlanner(FakeReleaseSource(), resolved_at=self.now).resolve(
+                configured, self.registry,
+                CanonicalProjects((("books/Demo", "v4.30.0"),)),
+            )
+            self.assertTrue(spec.include_historical_versions)
+            self.assertTrue(all(p.canonical for p in spec.projects))
+            self.assertEqual(len(spec.projects), 2)
+            self.assertIn("mode: canonical", dump_profile_snapshot(configured))
+            with self.assertRaises(DeployConfigError):
+                replace(configured, selection_mode="unknown")
+
     def test_canonical_replacement_accepts_explicit_root_doc_file(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)

--- a/sdk/deploy/tests/test_static_assets.py
+++ b/sdk/deploy/tests/test_static_assets.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+import tempfile
+import unittest
+
+from reasbook_deploy_sdk.release.static_assets import deduplicate_verso_assets
+
+
+class StaticAssetTests(unittest.TestCase):
+    def test_shared_head_preserves_order_body_and_docs(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            script = 'window.shared = "' + 'x' * 500 + '";'
+            css = 'p {color: red;}\n' * 40
+            body = '<body><pre>theorem x : True := by trivial</pre><script>body()</script></body>'
+            source = ('<html><head><script>window.__versoSiteRoot="/ReasBook/";</script>'
+                      f'<style>{css}</style><script>{script}</script></head>' + body + '</html>')
+            for name in ('a.html', 'b.html', 'docs/index.html'):
+                p = root / name
+                p.parent.mkdir(exist_ok=True)
+                p.write_text(source)
+            report = deduplicate_verso_assets(root, '/ReasBook/')
+            self.assertEqual(report['assets'], 2)
+            self.assertEqual(report['replaced_blocks'], 4)
+            self.assertGreater(report['saved_bytes'], 0)
+            changed = (root / 'a.html').read_text()
+            self.assertIn(body, changed)
+            self.assertLess(changed.index('<link '), changed.index('<script src='))
+            self.assertNotIn('async', changed)
+            self.assertEqual((root / 'docs/index.html').read_text(), source)
+            self.assertEqual(deduplicate_verso_assets(root, '/ReasBook/')['replaced_blocks'], 0)
+
+    def test_context_sensitive_and_inert_blocks_unchanged(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            filler = ' ' * 300
+            head = ('<script>window.__versoSiteRoot="/ReasBook/";</script>'
+                    f'<script>{filler}document.currentScript.src</script>'
+                    f'<style>{filler}a {{background:url(../image.png)}}</style>'
+                    f'<script type="module">{filler}import("./module.js")</script>'
+                    f'<!--<script>{filler}evil()</script>-->'
+                    f'<template><script>{filler}inert()</script></template>'
+                    f'<noscript><style>{filler}p {{color:red}}</style></noscript>')
+            source = '<html><head>' + head + '</head><body>Content</body></html>'
+            for name in ('a.html','b.html'):
+                (root/name).write_text(source)
+            report = deduplicate_verso_assets(root, '/ReasBook/')
+            self.assertEqual(report['replaced_blocks'], 0)
+            self.assertEqual((root/'a.html').read_text(), source)
+
+    def test_csp_documents_are_not_rewritten(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            source = ('<html><head><meta http-equiv="Content-Security-Policy" content="script-src none">'
+                      '<script>window.__versoSiteRoot="/ReasBook/";' + ' ' * 300 + '</script></head></html>')
+            for name in ('a.html', 'b.html'):
+                (root/name).write_text(source)
+            self.assertEqual(deduplicate_verso_assets(root, '/ReasBook/')['assets'], 0)
+            self.assertEqual((root/'a.html').read_text(), source)
+
+    def test_non_verso_html_not_rewritten(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            source = '<html><head><style>' + 'p {color:red}\n' * 100 + '</style></head></html>'
+            for name in ('a.html','b.html'):
+                (root/name).write_text(source)
+            self.assertEqual(deduplicate_verso_assets(root, '/ReasBook/')['assets'], 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_repository_scripts.py
+++ b/tests/test_repository_scripts.py
@@ -36,6 +36,33 @@ def working_directory(path: Path):
 
 
 class RepositoryScriptTests(unittest.TestCase):
+    def test_missing_api_link_requires_verified_matching_pinned_source(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            original = "https://github.com/acme/books/blob/v4.30.0/ReasBook/Demo/Item.lean"
+            pinned = original.replace("v4.30.0", "a" * 40)
+            doc = root / "index.html"
+            source = ('<main><p>Item (<a href="/ReasBook/docs/Item.html">API documentation</a>) '
+                      f'(<a href="{original}">Lean source</a>)</p>'
+                      '<a href="/ReasBook/missing.html">Unrelated</a></main>')
+            doc.write_text(source)
+            self.assertEqual(assemble.reconcile_documentation_links(root)["replacement_count"], 0)
+            result = assemble.reconcile_documentation_links(root, verified_source_links={original: pinned})
+            self.assertEqual(result["replacement_count"], 1)
+            text = doc.read_text()
+            self.assertIn("API documentation unavailable", text)
+            self.assertIn(pinned, text)
+            self.assertIn('href="/ReasBook/missing.html"', text)
+            self.assertFalse((root / "docs/Item.html").exists())
+            for invalid in (original, pinned.replace("Item.lean", "Other.lean")):
+                doc.write_text(source)
+                result = assemble.reconcile_documentation_links(root, verified_source_links={original: invalid})
+                self.assertEqual(result["replacement_count"], 0)
+            (root / "docs").mkdir()
+            (root / "docs/Item.html").write_text("Real documentation")
+            doc.write_text(source)
+            self.assertEqual(assemble.reconcile_documentation_links(root, verified_source_links={original: pinned})["replacement_count"], 0)
+
     @staticmethod
     def _project_docs_fixture(root: Path) -> tuple[Path, Path, Path, Path]:
         repo = root / "repo"


### PR DESCRIPTION
## Changes
- Explicit canonical project selection with stable version-qualified URLs. Old releases/caches are retained.
- Deterministic sharing of repeated Verso head scripts/styles; no proof/body truncation and no Docs HTML rewriting.
- Preserve historical reading links, strict release limits and immutable publication checks.
- Tests and ADR-0019 document the selection/cache boundaries.

## Validation
SDK offline tests pass, including asset order/body preservation, idempotence, CSP/relative-resource/module exclusions and canonical planning. Production-like cache composition and browser acceptance are being verified before Pages publication. No credentials, user comments, databases, caches or runtime configuration are included.