### PR TITLE
[Catalog] Add DFP Wolfe paper to main catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ into compilable Lean 4 projects.
 
 | Branch | Lean/mathlib | Registry status | Books/Papers |
 | --- | --- | --- | ---: |
-| `v4.32.0` | `v4.32.0` | Empty | 1 / 0 |
+| `v4.32.0` | `v4.32.0` | Empty | 1 / 1 |
 | `v4.32.2` | `v4.32.2` | Active | 0 / 1 |
 | `v4.30.0` | `v4.30.0` | Active | 10 / 2 |
 | `v4.26.0` | `v4.26.0` | Active | 4 / 2 |
@@ -139,6 +139,7 @@ Titles open their catalog pages; version links open the Lean source directly.
 
 | Formalization | Source | Contributors | Resources |
 | --- | :---: | --- | --- |
+| **[A Counterexample to Global Convergence of Classical DFP Under the Standard Strong Wolfe Conditions](ReasBook/Papers/DFP_wolfe_local/)**<br><sub>Benqi Liu, Zichen Wang, Zaiwen Wen, Liwei Zhang, and Yaxiang Yuan</sub> | [`v4.32.0`](https://github.com/optpku/ReasBook/tree/v4.32.0/ReasBook/Papers/DFP_wolfe_local/) | Zichen Wang | [arXiv](https://arxiv.org/html/2608.21708v1) |
 | **[A Fixed-Penalty Linearized Augmented Lagrangian Method with Classical Multiplier Updates](ReasBook/Papers/TR_LALM_theory/)**<br><sub>Benqi Liu, Kangkang Deng, Zichen Wang, and Zaiwen Wen</sub> | [`v4.32.2`](https://github.com/optpku/ReasBook/tree/v4.32.2/ReasBook/Papers/TR_LALM_theory/) | Zichen Wang, Zaiwen Wen | [Docs](https://optpku.github.io/ReasBook/docs/ReasBook/Papers/TR_LALM_theory/Paper.html) &#124; [Verso](https://optpku.github.io/ReasBook/sites/tr_lalm_theory/pages/) &#124; [Theorem map](https://optpku.github.io/ReasBook/theorem-maps/papers/tr_lalm_theory/) |
 | **[Smooth Minimization of Non-Smooth Functions](ReasBook/Papers/SmoothMinimization_Nesterov_2004/)**<br><sub>Yurii Nesterov (2004)</sub> | [`v4.26.0`](https://github.com/optpku/ReasBook/tree/v4.26.0/ReasBook/Papers/SmoothMinimization_Nesterov_2004/)<br>[`v4.30.0`](https://github.com/optpku/ReasBook/tree/v4.30.0/ReasBook/Papers/SmoothMinimization_Nesterov_2004/) | Wanli Ma, Zichen Wang, Zaiwen Wen | [Docs](https://optpku.github.io/ReasBook/docs/ReasBook/Papers/SmoothMinimization_Nesterov_2004/Paper.html) &#124; [Verso](https://optpku.github.io/ReasBook/sites/smoothminimization_nesterov_2004/pages/) |
 | **[On Some Local Rings](ReasBook/Papers/OnSomeLocalRings_Maassaran_2025/)**<br><sub>Mohamad Maassarani (2025)</sub> | [`v4.26.0`](https://github.com/optpku/ReasBook/tree/v4.26.0/ReasBook/Papers/OnSomeLocalRings_Maassaran_2025/)<br>[`v4.30.0`](https://github.com/optpku/ReasBook/tree/v4.30.0/ReasBook/Papers/OnSomeLocalRings_Maassaran_2025/) | Liang Xiao, Haochen Ju, Zichen Wang, Zaiwen Wen | [Docs](https://optpku.github.io/ReasBook/docs/ReasBook/Papers/OnSomeLocalRings_Maassaran_2025/Paper.html) &#124; [Verso](https://optpku.github.io/ReasBook/sites/onsomelocalrings_maassaran_2025/pages/) |

--- a/ReasBook/Papers/DFP_wolfe_local/README.md
+++ b/ReasBook/Papers/DFP_wolfe_local/README.md
@@ -1,0 +1,11 @@
+# A Counterexample to Global Convergence of Classical DFP Under the Standard Strong Wolfe Conditions
+
+This is a catalog link folder on `main`; the complete Lean formalization is
+kept on the `v4.32.0` version branch.
+
+- **Authors:** Benqi Liu, Zichen Wang, Zaiwen Wen, Liwei Zhang, and Yaxiang Yuan
+- **Paper:** [arXiv HTML](https://arxiv.org/html/2608.21708v1)
+- **Contributor:** Zichen Wang ([@imathwy](https://github.com/imathwy))
+- **License:** Apache License, Version 2.0
+
+**[Open the source on `v4.32.0`](https://github.com/optpku/ReasBook/tree/v4.32.0/ReasBook/Papers/DFP_wolfe_local/)**

--- a/ReasBook/Papers/README.md
+++ b/ReasBook/Papers/README.md
@@ -5,6 +5,7 @@ Open a paper below and use its source link to jump to the matching version branc
 
 | Formalization | Links |
 | --- | :---: |
+| **[A Counterexample to Global Convergence of Classical DFP Under the Standard Strong Wolfe Conditions](./DFP_wolfe_local/)**<br><sub>Benqi Liu, Zichen Wang, Zaiwen Wen, Liwei Zhang, and Yaxiang Yuan</sub> | [`v4.32.0 source`](https://github.com/optpku/ReasBook/tree/v4.32.0/ReasBook/Papers/DFP_wolfe_local/)<br>[arXiv](https://arxiv.org/html/2608.21708v1) |
 | **[A Fixed-Penalty Linearized Augmented Lagrangian Method with Classical Multiplier Updates](./TR_LALM_theory/)**<br><sub>Benqi Liu, Kangkang Deng, Zichen Wang, and Zaiwen Wen</sub> | [`v4.32.2 source`](https://github.com/optpku/ReasBook/tree/v4.32.2/ReasBook/Papers/TR_LALM_theory/)<br>[Theorem map](https://optpku.github.io/ReasBook/theorem-maps/papers/tr_lalm_theory/) |
 | **[Smooth Minimization of Non-Smooth Functions](./SmoothMinimization_Nesterov_2004/)**<br><sub>Yurii Nesterov (2004)</sub> | [`v4.26.0`](https://github.com/optpku/ReasBook/tree/v4.26.0/ReasBook/Papers/SmoothMinimization_Nesterov_2004/)<br>[`v4.30.0`](https://github.com/optpku/ReasBook/tree/v4.30.0/ReasBook/Papers/SmoothMinimization_Nesterov_2004/) |
 | **[On Some Local Rings](./OnSomeLocalRings_Maassaran_2025/)**<br><sub>Mohamad Maassarani (2025)</sub> | [`v4.26.0`](https://github.com/optpku/ReasBook/tree/v4.26.0/ReasBook/Papers/OnSomeLocalRings_Maassaran_2025/)<br>[`v4.30.0`](https://github.com/optpku/ReasBook/tree/v4.30.0/ReasBook/Papers/OnSomeLocalRings_Maassaran_2025/) |

--- a/apps/reasbook-reviewer/tests/test_catalog.py
+++ b/apps/reasbook-reviewer/tests/test_catalog.py
@@ -49,10 +49,11 @@ class CatalogTests(unittest.TestCase):
         records = discover_books(REPOSITORY_ROOT, include_papers=True)
         papers = [record for record in records if record.kind == "paper"]
 
-        self.assertEqual(len(papers), 3)
+        self.assertEqual(len(papers), 4)
         self.assertEqual(
             {paper.slug for paper in papers},
             {
+                "dfp_wolfe_local",
                 "onsomelocalrings_maassaran_2025",
                 "smoothminimization_nesterov_2004",
                 "tr_lalm_theory",


### PR DESCRIPTION
## Summary

- Add the merged DFP Wolfe paper to the cross-version Papers catalog.
- Add the `DFP_wolfe_local` link-folder README with the arXiv and `v4.32.0` source links, contributor, and Apache License 2.0.
- Correct the `v4.32.0` catalog count to `1 / 1` while preserving its registered `Empty` status.
- No generated documentation, Verso, or theorem-map resource is claimed.

## Validation

- `git diff --check`
- Local Markdown relative-link audit
- HTTP 200 checks for the arXiv page and merged source directory

The source contribution was merged in PR #48.