### PR TITLE
docs: add BFGS paper to main catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ into compilable Lean 4 projects.
 | Branch | Lean/mathlib | Registry status | Books/Papers |
 | --- | --- | --- | ---: |
 | `v4.32.0` | `v4.32.0` | Empty | 1 / 0 |
-| `v4.32.2` | `v4.32.2` | Active | 0 / 1 |
+| `v4.32.2` | `v4.32.2` | Active | 0 / 2 |
 | `v4.30.0` | `v4.30.0` | Active | 10 / 2 |
 | `v4.26.0` | `v4.26.0` | Active | 4 / 2 |
 
@@ -139,6 +139,7 @@ Titles open their catalog pages; version links open the Lean source directly.
 
 | Formalization | Source | Contributors | Resources |
 | --- | :---: | --- | --- |
+| **[The Minimum Q-Order of BFGS with Exact Line Search Is One](ReasBook/Papers/BFGSMinimumQOrder_Liu_2026/)**<br><sub>Benqi Liu, Chenyi Li, and Zaiwen Wen (2026)</sub> | [`v4.32.2`](https://github.com/optpku/ReasBook/tree/v4.32.2/ReasBook/Papers/BFGSMinimumQOrder_Liu_2026/) | Chenyi Li | Source only (documentation pending) |
 | **[A Fixed-Penalty Linearized Augmented Lagrangian Method with Classical Multiplier Updates](ReasBook/Papers/TR_LALM_theory/)**<br><sub>Benqi Liu, Kangkang Deng, Zichen Wang, and Zaiwen Wen</sub> | [`v4.32.2`](https://github.com/optpku/ReasBook/tree/v4.32.2/ReasBook/Papers/TR_LALM_theory/) | Zichen Wang, Zaiwen Wen | [Docs](https://optpku.github.io/ReasBook/docs/ReasBook/Papers/TR_LALM_theory/Paper.html) &#124; [Verso](https://optpku.github.io/ReasBook/sites/tr_lalm_theory/pages/) &#124; [Theorem map](https://optpku.github.io/ReasBook/theorem-maps/papers/tr_lalm_theory/) |
 | **[Smooth Minimization of Non-Smooth Functions](ReasBook/Papers/SmoothMinimization_Nesterov_2004/)**<br><sub>Yurii Nesterov (2004)</sub> | [`v4.26.0`](https://github.com/optpku/ReasBook/tree/v4.26.0/ReasBook/Papers/SmoothMinimization_Nesterov_2004/)<br>[`v4.30.0`](https://github.com/optpku/ReasBook/tree/v4.30.0/ReasBook/Papers/SmoothMinimization_Nesterov_2004/) | Wanli Ma, Zichen Wang, Zaiwen Wen | [Docs](https://optpku.github.io/ReasBook/docs/ReasBook/Papers/SmoothMinimization_Nesterov_2004/Paper.html) &#124; [Verso](https://optpku.github.io/ReasBook/sites/smoothminimization_nesterov_2004/pages/) |
 | **[On Some Local Rings](ReasBook/Papers/OnSomeLocalRings_Maassaran_2025/)**<br><sub>Mohamad Maassarani (2025)</sub> | [`v4.26.0`](https://github.com/optpku/ReasBook/tree/v4.26.0/ReasBook/Papers/OnSomeLocalRings_Maassaran_2025/)<br>[`v4.30.0`](https://github.com/optpku/ReasBook/tree/v4.30.0/ReasBook/Papers/OnSomeLocalRings_Maassaran_2025/) | Liang Xiao, Haochen Ju, Zichen Wang, Zaiwen Wen | [Docs](https://optpku.github.io/ReasBook/docs/ReasBook/Papers/OnSomeLocalRings_Maassaran_2025/Paper.html) &#124; [Verso](https://optpku.github.io/ReasBook/sites/onsomelocalrings_maassaran_2025/pages/) |

--- a/ReasBook/Papers/BFGSMinimumQOrder_Liu_2026/README.md
+++ b/ReasBook/Papers/BFGSMinimumQOrder_Liu_2026/README.md
@@ -1,0 +1,8 @@
+# The Minimum Q-Order of BFGS with Exact Line Search Is One
+
+This is a catalog link folder on `main`; the complete Lean formalization is
+kept on the version branch.
+
+**[Open the source on `v4.32.2`](https://github.com/optpku/ReasBook/tree/v4.32.2/ReasBook/Papers/BFGSMinimumQOrder_Liu_2026/)**
+
+Paper: [arXiv:2609.00596](https://arxiv.org/abs/2609.00596)

--- a/ReasBook/Papers/README.md
+++ b/ReasBook/Papers/README.md
@@ -5,6 +5,7 @@ Open a paper below and use its source link to jump to the matching version branc
 
 | Formalization | Links |
 | --- | :---: |
+| **[The Minimum Q-Order of BFGS with Exact Line Search Is One](./BFGSMinimumQOrder_Liu_2026/)**<br><sub>Benqi Liu, Chenyi Li, and Zaiwen Wen (2026)</sub> | [`v4.32.2 source`](https://github.com/optpku/ReasBook/tree/v4.32.2/ReasBook/Papers/BFGSMinimumQOrder_Liu_2026/) |
 | **[A Fixed-Penalty Linearized Augmented Lagrangian Method with Classical Multiplier Updates](./TR_LALM_theory/)**<br><sub>Benqi Liu, Kangkang Deng, Zichen Wang, and Zaiwen Wen</sub> | [`v4.32.2 source`](https://github.com/optpku/ReasBook/tree/v4.32.2/ReasBook/Papers/TR_LALM_theory/)<br>[Theorem map](https://optpku.github.io/ReasBook/theorem-maps/papers/tr_lalm_theory/) |
 | **[Smooth Minimization of Non-Smooth Functions](./SmoothMinimization_Nesterov_2004/)**<br><sub>Yurii Nesterov (2004)</sub> | [`v4.26.0`](https://github.com/optpku/ReasBook/tree/v4.26.0/ReasBook/Papers/SmoothMinimization_Nesterov_2004/)<br>[`v4.30.0`](https://github.com/optpku/ReasBook/tree/v4.30.0/ReasBook/Papers/SmoothMinimization_Nesterov_2004/) |
 | **[On Some Local Rings](./OnSomeLocalRings_Maassaran_2025/)**<br><sub>Mohamad Maassarani (2025)</sub> | [`v4.26.0`](https://github.com/optpku/ReasBook/tree/v4.26.0/ReasBook/Papers/OnSomeLocalRings_Maassaran_2025/)<br>[`v4.30.0`](https://github.com/optpku/ReasBook/tree/v4.30.0/ReasBook/Papers/OnSomeLocalRings_Maassaran_2025/) |


### PR DESCRIPTION
## Summary

- add BFGS minimum-Q-order formalization to the main Papers catalog
- add the main-branch link folder pointing to the v4.32.2 source
- update the v4.32.2 Books/Papers count

Related: #50